### PR TITLE
Improve Svelte example

### DIFF
--- a/examples/svelte/imports/ui/App.svelte
+++ b/examples/svelte/imports/ui/App.svelte
@@ -13,8 +13,11 @@
     counter += 1;
   }
 
-  const ready = useTracker(() => Meteor.subscribe('links.all'))
   $: links = LinksCollection.find({});
+
+  const remove = (linkId) => {
+    Meteor.call('links.remove', linkId)
+  }
 </script>
 
 
@@ -25,15 +28,18 @@
   <p>You've pressed the button {counter} times.</p>
 
   <h2>Learn Meteor!</h2>
-  {#if $ready}
+  {#await Meteor.subscribe('links.all')}
+    <div>Waiting on links...</div>
+  {:then}
     <ul>
       {#each $links as link (link._id)}
-        <li><a href={link.url} target="_blank" rel="noreferrer">{link.title}</a></li>
+        <li>
+          <a href={link.url} target="_blank" rel="noreferrer">{link.title}</a>
+          <button on:click={() => { remove(link._id) }}>✕</button>
+        </li>
       {/each}
     </ul>
-  {:else}
-    <div>Waiting on links...</div>
-  {/if}
+  {/await}
 
   <h2>Typescript ready</h2>
   <p>Just add lang="ts" to .svelte components.</p>

--- a/examples/svelte/server/main.ts
+++ b/examples/svelte/server/main.ts
@@ -9,6 +9,12 @@ Meteor.publish('links.all', function publishLinksAll() {
   return LinksCollection.find();
 })
 
+Meteor.methods({
+  async 'links.remove'(linkId) {
+    await LinksCollection.removeAsync(linkId);
+  }
+})
+
 Meteor.startup(async () => {
   // If the Links collection is empty, add some data.
   if (await LinksCollection.find().countAsync() === 0) {


### PR DESCRIPTION
I fixed the Svelte example.

Though I had issues starting the example project as it is:
1. I had to remove `"postinstall": "npm run build:dependencies"`, replace `"meteor-vite": "file:../../npm-packages/meteor-vite"` with `"meteor-vite": "^1.2.1"` and run `meteor run` instead of `npm start` due to this error:
![image](https://github.com/JorgenVatle/meteor-vite/assets/38740713/6116be72-fa81-4608-895b-4bb08b2ada16)

2. I had to remove `./meteor/versions` due to this error: 
![image](https://github.com/JorgenVatle/meteor-vite/assets/38740713/563cf132-e392-4ced-958f-00c3118e2f7a)

In my opinion, example project should not reference local files so it can be copied to the target project as is. So I would suggest to:
1. Remove `packages` file.
2. Replace `"meteor-vite": "file:...` with `"meteor-vite": "<version>`.
3. Remove `.meteor/version`.