### PR TITLE
Improve error handling for Vite MeteorStubs plugin & implement dynamic lazy loading without resorting to throwing errors.

### DIFF
--- a/.changeset/lemon-queens-buy.md
+++ b/.changeset/lemon-queens-buy.md
@@ -1,0 +1,6 @@
+---
+"meteor-vite": minor
+---
+
+- Update MeteorStubs plugin error handler to emit errors when a Meteor client entrypoint isn't specified
+- Wrap MeteorStubs plugin around plugin setup helper function to catch and format exceptions whenever possible

--- a/.changeset/olive-taxis-divide.md
+++ b/.changeset/olive-taxis-divide.md
@@ -1,0 +1,5 @@
+---
+"vite-bundler": minor
+---
+
+Transmit Meteor's IPC messages through to Vite worker process, enabling Meteor-Vite to gracefully import lazy-loaded packages for the client without throwing errors.

--- a/examples/svelte/.meteor/versions
+++ b/examples/svelte/.meteor/versions
@@ -30,7 +30,7 @@ html-tools@1.1.3
 htmljs@1.1.1
 id-map@1.1.1
 inter-process-messaging@0.1.1
-jorgenvatle:vite-bundler@1.2.1
+jorgenvatle:vite-bundler@1.2.2
 launch-screen@1.3.0
 logging@1.3.2
 meteor@1.11.2

--- a/npm-packages/meteor-vite/src/HelperTypes.ts
+++ b/npm-packages/meteor-vite/src/HelperTypes.ts
@@ -1,3 +1,3 @@
 export type DeepPartial<TObject> = TObject extends {} ? {
-    [key in keyof TObject]: DeepPartial<TObject[key]>
+    [key in keyof TObject]?: DeepPartial<TObject[key]>
 } : TObject;

--- a/npm-packages/meteor-vite/src/HelperTypes.ts
+++ b/npm-packages/meteor-vite/src/HelperTypes.ts
@@ -1,0 +1,3 @@
+export type DeepPartial<TObject> = TObject extends {} ? {
+    [key in keyof TObject]: DeepPartial<TObject[key]>
+} : TObject;

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -29,7 +29,7 @@ export default CreateIPCInterface({
     },
     
     async 'meteor.ipcMessage'(reply, data: MeteorIPCMessage) {
-        MeteorEvents.transmit(data);
+        MeteorEvents.ingest(data);
     },
     
     // todo: Add reply for triggering a server restart

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -1,6 +1,7 @@
 import Path from 'path';
 import { createServer, resolveConfig, ViteDevServer } from 'vite';
 import Logger from '../../Logger';
+import MeteorEvents, { MeteorIPCMessage } from '../../meteor/MeteorEvents';
 import { MeteorViteConfig } from '../../vite/MeteorViteConfig';
 import { MeteorStubs } from '../../vite';
 import { ProjectJson } from '../../vite/plugin/MeteorStubs';
@@ -25,6 +26,10 @@ type Replies = IPCReply<{
 export default CreateIPCInterface({
     async 'vite.getDevServerConfig'(replyInterface: Replies) {
         sendViteConfig(replyInterface);
+    },
+    
+    async 'meteor.ipcMessage'(reply, data: MeteorIPCMessage) {
+        MeteorEvents.transmit(data);
     },
     
     // todo: Add reply for triggering a server restart

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -4,6 +4,7 @@ import Logger from '../../Logger';
 import { MeteorViteConfig } from '../../vite/MeteorViteConfig';
 import { MeteorStubs } from '../../vite';
 import { ProjectJson } from '../../vite/plugin/MeteorStubs';
+import { RefreshNeeded } from '../../vite/ViteLoadRequest';
 import CreateIPCInterface, { IPCReply } from './IPC/interface';
 
 let server: ViteDevServer & { config: MeteorViteConfig };
@@ -16,6 +17,9 @@ type Replies = IPCReply<{
         port?: number;
         entryFile?: string
     }
+} | {
+    kind: 'refreshNeeded',
+    data: {},
 }>
 
 export default CreateIPCInterface({
@@ -52,7 +56,18 @@ export default CreateIPCInterface({
                     },
                 ],
             });
+            
+            process.on('warning', (warning) => {
+                if (warning.name !== RefreshNeeded.name) {
+                    return;
+                }
+                replyInterface({
+                    kind: 'refreshNeeded',
+                    data: {},
+                })
+            })
         }
+        
         
         let listening = false
         await server.listen()

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -12,12 +12,24 @@ export type MeteorIPCMessage = {
 export default new class MeteorEvents {
     protected readonly events = new EventEmitter();
     
-    public awaitClientRefresh(timeoutMs: number) {
+    public awaitEvent(event: {
+        /**
+         * Meteor IPC event name.
+         * E.g. webapp-reload-client, client-refresh
+         */
+        topic: MeteorIPCTopic,
+        
+        /**
+         * How long to wait before rejecting the promise.
+         * Useful to prevent a promise from hanging indefinitely.
+         */
+        timeoutMs: number
+    }) {
         return new Promise<void>((resolve, reject) => {
             let rejected = false;
             let resolved = false;
             
-            this.events.once('webapp-reload-client', () => {
+            this.events.once(event.topic, () => {
                 if (rejected) return;
                 resolved = true;
                 resolve()
@@ -27,7 +39,7 @@ export default new class MeteorEvents {
                 if (resolved) return;
                 rejected = true;
                 reject(new EventTimeout('Timed out waiting for client refresh event'));
-            }, timeoutMs)
+            }, event.timeoutMs)
         })
     }
     

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import pc from 'picocolors';
 import Logger from '../Logger';
 
 type MeteorIPCTopic = 'webapp-reload-client' | 'webapp-pause-client' | 'client-refresh';
@@ -40,7 +41,8 @@ export default new class MeteorEvents {
                 this.events.once(topic, () => {
                     if (rejected || resolved) return;
                     resolved = true;
-                    resolve()
+                    resolve();
+                    Logger.debug(`MeteorEvents event listener received an awaited event: ${pc.yellow(topic)}`)
                 });
             })
             

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from 'events';
+
+type MeteorIPCTopic = 'webapp-reload-client' | 'webapp-pause-client' | 'client-refresh';
+
+export type MeteorIPCMessage = {
+    type: 'METEOR_IPC_MESSAGE',
+    responseId: string,
+    topic: MeteorIPCTopic,
+    encodedPayload: string
+}
+
+export default new class MeteorEvents extends EventEmitter {
+    public awaitClientRefresh() {
+        return new Promise((resolve, reject) => {
+            this.once('webapp-reload-client', resolve);
+        })
+    }
+    
+    public transmit(event: MeteorIPCTopic) {
+        super.emit(event);
+    }
+    
+    protected waitFor(eventName: MeteorIPCTopic, listener: (...args: any[]) => void) {
+        return super.once(eventName, listener);
+    }
+}

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -18,12 +18,12 @@ export default new class MeteorEvents {
      * @param {{topics: MeteorIPCTopic[], timeoutMs: number}} event
      * @returns {Promise<void>}
      */
-    public awaitEvent(event: {
+    public waitForMessage(event: {
         /**
          * Meteor IPC event name.
          * E.g. webapp-reload-client, client-refresh
          */
-        topics: MeteorIPCTopic[],
+        topic: MeteorIPCTopic[],
         
         /**
          * How long to wait before rejecting the promise.
@@ -35,7 +35,7 @@ export default new class MeteorEvents {
             let rejected = false;
             let resolved = false;
             
-            event.topics.forEach((topic) => {
+            event.topic.forEach((topic) => {
                 this.events.once(topic, () => {
                     if (rejected || resolved) return;
                     resolved = true;

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -9,18 +9,17 @@ export type MeteorIPCMessage = {
     encodedPayload: string
 }
 
-export default new class MeteorEvents extends EventEmitter {
+
+export default new class MeteorEvents {
+    protected readonly events = new EventEmitter();
+    
     public awaitClientRefresh() {
         return new Promise((resolve, reject) => {
-            this.once('webapp-reload-client', resolve);
+            this.events.once('webapp-reload-client', resolve);
         })
     }
     
-    public transmit(event: MeteorIPCMessage) {
-        super.emit(event.type);
-    }
-    
-    protected waitFor(eventName: MeteorIPCTopic, listener: (...args: any[]) => void) {
-        return super.once(eventName, listener);
+    public ingest(event: MeteorIPCMessage) {
+        this.events.emit(event.type);
     }
 }

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -52,7 +52,7 @@ export default new class MeteorEvents {
     }
     
     public ingest(event: MeteorIPCMessage) {
-        this.events.emit(event.type);
+        this.events.emit(event.topic);
     }
 }
 

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -16,8 +16,8 @@ export default new class MeteorEvents extends EventEmitter {
         })
     }
     
-    public transmit(event: MeteorIPCTopic) {
-        super.emit(event);
+    public transmit(event: MeteorIPCMessage) {
+        super.emit(event.type);
     }
     
     protected waitFor(eventName: MeteorIPCTopic, listener: (...args: any[]) => void) {

--- a/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
+++ b/npm-packages/meteor-vite/src/meteor/MeteorEvents.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import Logger from '../Logger';
 
 type MeteorIPCTopic = 'webapp-reload-client' | 'webapp-pause-client' | 'client-refresh';
 
@@ -51,8 +52,9 @@ export default new class MeteorEvents {
         })
     }
     
-    public ingest(event: MeteorIPCMessage) {
-        this.events.emit(event.topic);
+    public ingest(message: MeteorIPCMessage) {
+        Logger.debug('Received Meteor IPC message:', message);
+        this.events.emit(message.topic);
     }
 }
 

--- a/npm-packages/meteor-vite/src/meteor/package/AutoImportQueue.ts
+++ b/npm-packages/meteor-vite/src/meteor/package/AutoImportQueue.ts
@@ -82,7 +82,6 @@ export default new class AutoImportQueue {
         return new Promise<void>((resolve, reject) => {
             this.onRestartWatchers.push(() => {
                 reject(
-                    // Todo: Look into a better way for forcing a restart without needing a potentially confusing error
                     new RefreshNeeded(`Terminating Vite server to load isopacks for new packages`, this.addedPackages)
                 )
             })

--- a/npm-packages/meteor-vite/src/meteor/package/AutoImportQueue.ts
+++ b/npm-packages/meteor-vite/src/meteor/package/AutoImportQueue.ts
@@ -59,7 +59,7 @@ export default new class AutoImportQueue {
         if (this.addedPackages.length > lastPackageCount && !skipRestart) {
             await MeteorEvents.waitForMessage({
                 topic: ['webapp-reload-client', 'client-refresh'],
-                timeoutMs: 5000,
+                timeoutMs: process.env.NODE_ENV === 'test' ? 50 : 5000, // todo: implement tests for this
             }).catch((error: Error) => {
                 if (error instanceof EventTimeout) {
                     Logger.warn(`Timed out waiting for Meteor to refresh the client for ${pc.yellow(importString)}!`)

--- a/npm-packages/meteor-vite/src/vite/ViteLoadRequest.ts
+++ b/npm-packages/meteor-vite/src/vite/ViteLoadRequest.ts
@@ -6,7 +6,7 @@ import { createLabelledLogger, LabelLogger } from '../Logger';
 import AutoImportQueue from '../meteor/package/AutoImportQueue';
 import { isSameModulePath } from '../meteor/package/Serialize';
 import { MeteorViteError } from './error/MeteorViteError';
-import type { PluginSettings, ValidProjectJson } from './plugin/MeteorStubs';
+import type { PluginSettings } from './plugin/MeteorStubs';
 
 export default class ViteLoadRequest {
     
@@ -186,7 +186,7 @@ export type FileRequestData = ReturnType<typeof ViteLoadRequest['loadFileData']>
 
 interface PreContextRequest {
     id: string;
-    pluginSettings: PluginSettings & { packageJson: ValidProjectJson };
+    pluginSettings: PluginSettings;
 }
 
 export interface RequestContext extends PreContextRequest {

--- a/npm-packages/meteor-vite/src/vite/ViteLoadRequest.ts
+++ b/npm-packages/meteor-vite/src/vite/ViteLoadRequest.ts
@@ -6,7 +6,7 @@ import { createLabelledLogger, LabelLogger } from '../Logger';
 import AutoImportQueue from '../meteor/package/AutoImportQueue';
 import { isSameModulePath } from '../meteor/package/Serialize';
 import { MeteorViteError } from './error/MeteorViteError';
-import type { PluginSettings } from './plugin/MeteorStubs';
+import type { PluginSettings, ValidProjectJson } from './plugin/MeteorStubs';
 
 export default class ViteLoadRequest {
     
@@ -146,11 +146,6 @@ export default class ViteLoadRequest {
      */
     public async forceImport() {
         const mainModule = this.context.pluginSettings.packageJson.meteor.mainModule;
-        
-        if (!mainModule?.client) {
-            throw new MeteorViteError(`No meteor.mainModule.client found in package.json`)
-        }
-        
         const meteorClientEntryFile = Path.resolve(process.cwd(), mainModule.client);
         
         if (!existsSync(meteorClientEntryFile)) {
@@ -191,7 +186,7 @@ export type FileRequestData = ReturnType<typeof ViteLoadRequest['loadFileData']>
 
 interface PreContextRequest {
     id: string;
-    pluginSettings: PluginSettings;
+    pluginSettings: PluginSettings & { packageJson: ValidProjectJson };
 }
 
 export interface RequestContext extends PreContextRequest {

--- a/npm-packages/meteor-vite/src/vite/error/ErrorHandler.ts
+++ b/npm-packages/meteor-vite/src/vite/error/ErrorHandler.ts
@@ -35,7 +35,7 @@ function formatError(fallbackDescription: string, error: unknown | Error) {
 
 let lastEmittedWarning = Date.now();
 function handleRefreshNeeded(error: RefreshNeeded): never {
-    if (5_000 < Date.now() - lastEmittedWarning) {
+    if (1000 < Date.now() - lastEmittedWarning) {
         console.warn(error.message);
         process.emitWarning('Refresh needed!', error.constructor.name);
         lastEmittedWarning = Date.now();

--- a/npm-packages/meteor-vite/src/vite/error/ErrorHandler.ts
+++ b/npm-packages/meteor-vite/src/vite/error/ErrorHandler.ts
@@ -16,7 +16,7 @@ export function createErrorHandler(fallbackDescription: string, request?: ViteLo
 
 function formatError(fallbackDescription: string, error: unknown | Error) {
     if (!(error instanceof Error)) {
-        throw new MeteorViteError('Received an unexpected error format!', { cause: error });
+        return new MeteorViteError('Received an unexpected error format!', { cause: error });
     }
     
     if (!(error instanceof MeteorViteError)) {

--- a/npm-packages/meteor-vite/src/vite/error/ErrorHandler.ts
+++ b/npm-packages/meteor-vite/src/vite/error/ErrorHandler.ts
@@ -1,0 +1,29 @@
+import ViteLoadRequest from '../ViteLoadRequest';
+import { MeteorViteError } from './MeteorViteError';
+
+export function createErrorHandler(fallbackDescription: string, request?: ViteLoadRequest) {
+    return async (error: unknown): Promise<never> => {
+        const viteError = await formatError(fallbackDescription, error);
+        
+        if (request) {
+            viteError.setContext(request);
+        }
+        
+        await viteError.beautify()
+        throw error;
+    }
+}
+
+function formatError(fallbackDescription: string, error: unknown | Error) {
+    if (!(error instanceof Error)) {
+        throw new MeteorViteError('Received an unexpected error format!', { cause: error });
+    }
+    
+    if (!(error instanceof MeteorViteError)) {
+        return new MeteorViteError(fallbackDescription, {
+            cause: error,
+        })
+    }
+    
+    return error;
+}

--- a/npm-packages/meteor-vite/src/vite/error/MeteorViteError.ts
+++ b/npm-packages/meteor-vite/src/vite/error/MeteorViteError.ts
@@ -20,7 +20,7 @@ export class MeteorViteError extends Error implements ErrorMetadata {
         this.context = context;
         this.package = meteorPackage;
         
-        if (cause && !subtitle) {
+        if (cause instanceof Error && !subtitle) {
             this.subtitle = `Caused by [${cause?.name}] ${cause?.message}`
         }
         if (cause) {
@@ -128,5 +128,5 @@ export interface ErrorMetadata {
     subtitle?: string;
     package?: Pick<MeteorPackage, 'packageId'>;
     context?: Pick<RequestContext, 'id'>;
-    cause?: Error;
+    cause?: Error | unknown;
 }

--- a/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
+++ b/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
@@ -2,6 +2,7 @@ import FS from 'fs/promises';
 import Path from 'path';
 import pc from 'picocolors';
 import { Plugin } from 'vite';
+import PackageJSON from '../../../package.json';
 import { DeepPartial } from '../../HelperTypes';
 import MeteorPackage from '../../meteor/package/MeteorPackage';
 import { stubTemplate } from '../../meteor/package/StubTemplate';
@@ -22,6 +23,12 @@ export function MeteorStubs(pluginSettings: PluginSettings): Plugin {
             
             async load(request) {
                 const timeStarted = Date.now();
+                
+                if (!pluginSettings?.packageJson?.meteor?.mainModule?.client || true) {
+                    throw new MeteorViteError(`You need to specify a Meteor entrypoint in your package.json!`, {
+                        subtitle: `See the following link for more info: ${PackageJSON.homepage}`
+                    })
+                }
                 
                 if (request.isLazyLoaded) {
                     await request.forceImport();

--- a/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
+++ b/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
@@ -23,7 +23,7 @@ export const MeteorStubs = setupPlugin(async (pluginSettings: PluginSettings) =>
         async load(request) {
             const timeStarted = Date.now();
             
-            if (!pluginSettings?.packageJson?.meteor?.mainModule?.client || true) {
+            if (!pluginSettings?.packageJson?.meteor?.mainModule?.client) {
                 throw new MeteorViteError(`You need to specify a Meteor entrypoint in your package.json!`, {
                     subtitle: `See the following link for more info: ${PackageJSON.homepage}`
                 })

--- a/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
+++ b/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
@@ -2,6 +2,7 @@ import FS from 'fs/promises';
 import Path from 'path';
 import pc from 'picocolors';
 import { Plugin } from 'vite';
+import { DeepPartial } from '../../HelperTypes';
 import MeteorPackage from '../../meteor/package/MeteorPackage';
 import { stubTemplate } from '../../meteor/package/StubTemplate';
 import { MeteorViteError } from '../error/MeteorViteError';
@@ -150,10 +151,11 @@ export interface PluginSettings {
  * The user's Meteor project package.json content.
  * todo: expand types
  */
-export type ProjectJson = {
-    meteor?: {
-        mainModule?: {
-            client?: string;
+export type ProjectJson = DeepPartial<ValidProjectJson>
+export type ValidProjectJson = {
+    meteor: {
+        mainModule: {
+            client: string;
         },
         viteConfig?: string;
     }

--- a/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
+++ b/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
@@ -12,6 +12,12 @@ import { StubValidationSettings } from '../MeteorViteConfig';
 import ViteLoadRequest from '../ViteLoadRequest';
 
 export const MeteorStubs = setupPlugin(async (pluginSettings: PluginSettings) => {
+    if (!pluginSettings?.packageJson?.meteor?.mainModule?.client) {
+        throw new MeteorViteError(`You need to specify a Meteor entrypoint in your package.json!`, {
+            subtitle: `See the following link for more info: ${PackageJSON.homepage}`
+        })
+    }
+    
     return {
         name: 'meteor-vite: stubs',
         resolveId: (id) => ViteLoadRequest.resolveId(id),
@@ -22,12 +28,6 @@ export const MeteorStubs = setupPlugin(async (pluginSettings: PluginSettings) =>
         
         async load(request) {
             const timeStarted = Date.now();
-            
-            if (!pluginSettings?.packageJson?.meteor?.mainModule?.client) {
-                throw new MeteorViteError(`You need to specify a Meteor entrypoint in your package.json!`, {
-                    subtitle: `See the following link for more info: ${PackageJSON.homepage}`
-                })
-            }
             
             if (request.isLazyLoaded) {
                 await request.forceImport();

--- a/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
+++ b/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
@@ -149,7 +149,7 @@ export interface PluginSettings {
      * Full content of the user's Meteor project package.json.
      * Like the one found in {@link /examples/vue/package.json}
      */
-    packageJson: ValidProjectJson;
+    packageJson: ProjectJson;
     
     /**
      * Enabling debug mode will write all input and output files to a `.meteor-vite` directory.
@@ -163,8 +163,7 @@ export interface PluginSettings {
  * The user's Meteor project package.json content.
  * todo: expand types
  */
-export type ProjectJson = DeepPartial<ValidProjectJson>
-export type ValidProjectJson = {
+export type ProjectJson = {
     meteor: {
         mainModule: {
             client: string;

--- a/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
+++ b/npm-packages/meteor-vite/src/vite/plugin/MeteorStubs.ts
@@ -149,7 +149,7 @@ export interface PluginSettings {
      * Full content of the user's Meteor project package.json.
      * Like the one found in {@link /examples/vue/package.json}
      */
-    packageJson: ProjectJson;
+    packageJson: ValidProjectJson;
     
     /**
      * Enabling debug mode will write all input and output files to a `.meteor-vite` directory.

--- a/packages/vite-bundler/vite-server.ts
+++ b/packages/vite-bundler/vite-server.ts
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor'
 import { WebAppInternals } from 'meteor/webapp'
 import type HTTP from 'http'
+import * as process from 'process';
 import {
     getConfig, DevConnectionLog,
     MeteorViteConfig,
@@ -30,6 +31,9 @@ if (Meteor.isDevelopment) {
                 DevConnectionLog.info(`Meteor-Vite ready for connections!`)
             }
         },
+        refreshNeeded() {
+            DevConnectionLog.info('Some lazy-loaded packages were imported, please refresh')
+        }
     });
     
     viteServer.call({

--- a/packages/vite-bundler/vite-server.ts
+++ b/packages/vite-bundler/vite-server.ts
@@ -7,7 +7,7 @@ import {
     setConfig,
     ViteConnection,
 } from './loading/vite-connection-handler';
-import { createWorkerFork, getProjectPackageJson } from './workers';
+import { createWorkerFork, getProjectPackageJson, isMeteorIPCMessage } from './workers';
 
 if (Meteor.isDevelopment) {
     DevConnectionLog.info('Starting Vite server...');
@@ -41,6 +41,14 @@ if (Meteor.isDevelopment) {
             packageJson: getProjectPackageJson(),
         }]
     });
+    
+    process.on('message', (message) => {
+        if (!isMeteorIPCMessage(message)) return;
+        viteServer.call({
+            method: 'meteor.ipcMessage',
+            params: [message],
+        })
+    })
     
     Meteor.publish(ViteConnection.publication, () => {
         return MeteorViteConfig.find(ViteConnection.configSelector);

--- a/packages/vite-bundler/vite-server.ts
+++ b/packages/vite-bundler/vite-server.ts
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor'
 import { WebAppInternals } from 'meteor/webapp'
 import type HTTP from 'http'
-import * as process from 'process';
 import {
     getConfig, DevConnectionLog,
     MeteorViteConfig,

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -50,8 +50,6 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
         })
     });
     
-    ['SIG']
-    
     return {
         call(method: Omit<WorkerMethod, 'replies'>) {
             child.send(method);

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -58,6 +58,28 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
     }
 }
 
+export type MeteorIPCMessage = {
+    type: 'METEOR_IPC_MESSAGE',
+    responseId: string,
+    topic: 'webapp-reload-client' | 'webapp-pause-client' | 'client-refresh',
+    encodedPayload: string
+}
+
+export function isMeteorMessage<
+    Topic extends MeteorIPCMessage['topic']
+>(message: unknown, event: Topic): message is Omit<MeteorIPCMessage, 'topic'> & { topic: Topic }  {
+    if (!message || typeof message !== 'object') {
+        return false;
+    }
+    if (!('type' in message) || !('topic' in message)) {
+        return false;
+    }
+    if (message?.type !== 'METEOR_IPC_MESSAGE') {
+        return false;
+    }
+    return message.topic === event;
+}
+
 class MeteorViteError extends Error {
     constructor(message: string[] | string) {
         if (!Array.isArray(message)) {

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -50,6 +50,8 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
         })
     });
     
+    ['SIG']
+    
     return {
         call(method: Omit<WorkerMethod, 'replies'>) {
             child.send(method);

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -59,9 +59,9 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
     }
 }
 
-export function isMeteorMessage<
+export function isMeteorIPCMessage<
     Topic extends MeteorIPCMessage['topic']
->(message: unknown, event: Topic): message is Omit<MeteorIPCMessage, 'topic'> & { topic: Topic }  {
+>(message: unknown): message is MeteorIPCMessage  {
     if (!message || typeof message !== 'object') {
         return false;
     }
@@ -71,7 +71,10 @@ export function isMeteorMessage<
     if (message?.type !== 'METEOR_IPC_MESSAGE') {
         return false;
     }
-    return message.topic === event;
+    if (typeof message.topic !== 'string') {
+        return false;
+    }
+    return true;
 }
 
 class MeteorViteError extends Error {

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -5,6 +5,7 @@ import FS from 'fs';
 import pc from 'picocolors';
 import type { WorkerMethod, WorkerResponse } from '../../npm-packages/meteor-vite';
 import type { WorkerResponseHooks } from '../../npm-packages/meteor-vite/src/bin/worker';
+import type { MeteorIPCMessage } from '../../npm-packages/meteor-vite/src/meteor/MeteorEvents';
 import type { ProjectJson } from '../../npm-packages/meteor-vite/src/vite/plugin/MeteorStubs';
 
 // Use a worker to skip reify and Fibers
@@ -56,13 +57,6 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
         },
         child,
     }
-}
-
-export type MeteorIPCMessage = {
-    type: 'METEOR_IPC_MESSAGE',
-    responseId: string,
-    topic: 'webapp-reload-client' | 'webapp-pause-client' | 'client-refresh',
-    encodedPayload: string
 }
 
 export function isMeteorMessage<


### PR DESCRIPTION
- Add wrapper around all errors emitted by the meteor-vite plugin so they are all formatted nicely
- Transmit Meteor IPC messages down to Vite worker.
  - Instead of throwing an error to force the client to refresh to get a new lazy-loaded package, the Vite worker will now wait for Meteor to refresh the client bundle. From there, the package stub will be processed like nothing happened. 🔥