### PR TITLE
Keep Vite server running between restarts

### DIFF
--- a/npm-packages/meteor-vite/src/bin/worker/package-build.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/package-build.ts
@@ -14,6 +14,7 @@ export default CreateIPCInterface({
         const child = spawn(tsupPath, ['--watch'], {
             stdio: 'inherit',
             cwd: npmPackagePath,
+            detached: false,
             env: {
                 FORCE_COLOR: '3',
             },

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -54,7 +54,9 @@ export default CreateIPCInterface({
                 kind: 'viteConfig',
                 data: worker.config.viteConfig,
             })
+            console.log('Testing testing!');
             console.log(`Vite server running as background process. (pid ${worker.config.pid})`);
+            process.exit(0);
             return;
         }
         
@@ -209,7 +211,7 @@ class BackgroundWorker {
             return false;
         }
         if (!this._isRunning(this.config.pid)) {
-            console.warn(`Background worker not running: ${this.config.pid} (current PID ${process.pid}) `, error);
+            console.warn(`Background worker not running: ${this.config.pid} (current PID ${process.pid}) `);
             return false;
         }
         return true;

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -148,23 +148,24 @@ class BackgroundWorker {
         if (BackgroundWorker.instance) {
             return BackgroundWorker.instance;
         }
+        const myConfig = {
+            pid: process.pid,
+            meteorPid: process.ppid,
+            meteorParentPid,
+            viteConfig: {}
+        };
         try {
             const content = await FS.readFile(this.configPath, 'utf-8');
             const config = JSON.parse(content);
             console.log('Retrieved runtime config from file: ', config)
             BackgroundWorker.instance = new BackgroundWorker(config);
         } catch (error) {
-            BackgroundWorker.instance = new BackgroundWorker({
-                pid: process.pid,
-                meteorPid: process.ppid,
-                meteorParentPid,
-                viteConfig: {}
-            })
+            BackgroundWorker.instance = new BackgroundWorker(myConfig)
         }
         
         const worker = BackgroundWorker.instance;
         if (!worker.isRunning) {
-            await worker.update(worker.config);
+            await worker.update(myConfig);
         }
         return worker;
     }

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -152,15 +152,21 @@ class BackgroundWorker {
             const content = await FS.readFile(this.configPath, 'utf-8');
             const config = JSON.parse(content);
             console.log('Retrieved runtime config from file: ', config)
-            return BackgroundWorker.instance = new BackgroundWorker(config);
+            BackgroundWorker.instance = new BackgroundWorker(config);
         } catch (error) {
-            return BackgroundWorker.instance = new BackgroundWorker({
+            BackgroundWorker.instance = new BackgroundWorker({
                 pid: process.pid,
                 meteorPid: process.ppid,
                 meteorParentPid,
                 viteConfig: {}
             })
         }
+        
+        const worker = BackgroundWorker.instance;
+        if (!worker.isRunning) {
+            await worker.update(worker.config);
+        }
+        return worker;
     }
     constructor(public config: WorkerRuntimeConfig) {
         console.log('Retrieved background process config', config);

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -13,16 +13,17 @@ let viteConfig: MeteorViteConfig;
 
 type Replies = IPCReply<{
     kind: 'viteConfig',
-    data: {
-        host?: string | boolean;
-        port?: number;
-        entryFile?: string
-    }
+    data: ViteRuntimeConfig;
 } | {
     kind: 'refreshNeeded',
     data: {},
 }>
 
+type ViteRuntimeConfig = {
+    host?: string | boolean;
+    port?: number;
+    entryFile?: string
+}
 interface DevServerOptions {
     packageJson: ProjectJson,
     globalMeteorPackagesDir: string;

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -222,18 +222,19 @@ async function sendViteConfig(reply: Replies) {
     }
     
     const { config } = server;
-    const data = {
+    const worker = BackgroundWorker.instance;
+    
+    await worker.setViteConfig({
         host: config.server?.host,
         port: config.server?.port,
         entryFile: config.meteor?.clientEntry,
-    };
-    
+    });
     reply({
         kind: 'viteConfig',
-        data: {
-            ...data,
-            backgroundWorker: BackgroundWorker.instance.config,
-        },
+        data: worker.config.viteConfig,
     });
-    await BackgroundWorker.instance.setViteConfig(data);
+    reply({
+        kind: 'workerConfig',
+        data: worker.config,
+    })
 }

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -19,6 +19,9 @@ type Replies = IPCReply<{
 } | {
     kind: 'refreshNeeded',
     data: {},
+} | {
+    kind: 'workerConfig';
+    data: WorkerRuntimeConfig;
 }>
 
 type ViteRuntimeConfig = {
@@ -146,7 +149,7 @@ type WorkerRuntimeConfig = {
 
 class BackgroundWorker {
     public static instance: BackgroundWorker;
-    protected static readonly configPath = './.meteor-vite-server.pid'
+    protected static readonly configPath = '.meteor-vite/vite-server.pid'
     public static async init(meteorParentPid: number) {
         if (BackgroundWorker.instance) {
             return BackgroundWorker.instance;

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -183,7 +183,7 @@ class BackgroundWorker {
         }
         // Keep track of Meteor's parent process to exit if it has ended abruptly.
         setInterval(() => {
-            if (this._isRunning(config.meteorParentPid)) {
+            if (this._isRunning(config.meteorPid)) {
                 return;
             }
             console.warn('Meteor parent process is no longer running. Shutting down...');
@@ -195,7 +195,7 @@ class BackgroundWorker {
             }).then(() => {
                 process.exit(1);
             })
-        }, 30_000)
+        }, 5_000)
     }
     
     protected _isRunning(pid: number) {

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -25,6 +25,7 @@ type ViteRuntimeConfig = {
     host?: string | boolean;
     port?: number;
     entryFile?: string
+    backgroundWorker?: WorkerRuntimeConfig;
 }
 interface DevServerOptions {
     packageJson: ProjectJson,
@@ -73,6 +74,7 @@ export default CreateIPCInterface({
         
         await server.listen()
         await sendViteConfig(replyInterface);
+        server.printUrls();
         listening = true
         return;
     },
@@ -225,7 +227,10 @@ async function sendViteConfig(reply: Replies) {
     
     reply({
         kind: 'viteConfig',
-        data,
+        data: {
+            ...data,
+            backgroundWorker: BackgroundWorker.instance.config,
+        },
     });
     await BackgroundWorker.instance.setViteConfig(data);
 }

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -54,7 +54,7 @@ export default CreateIPCInterface({
                 kind: 'viteConfig',
                 data: backgroundWorker.config.viteConfig,
             })
-            console.log(`Vite server running as background process. (pid ${backgroundWorker.config.pid})`);
+            Logger.info(`Vite server running as background process. (pid ${backgroundWorker.config.pid})`);
             return process.exit(0);
         }
         
@@ -69,7 +69,7 @@ export default CreateIPCInterface({
             },
             buildStart: () => {
                 sendViteConfig(replyInterface).catch((error) => {
-                    console.error(error);
+                    Logger.error(error);
                     process.exit(1);
                 });
             },
@@ -85,11 +85,11 @@ export default CreateIPCInterface({
     async 'vite.stopDevServer'() {
         if (!server) return;
         try {
-            console.log('Shutting down vite server...');
+            Logger.info('Shutting down vite server...');
             await server.close()
-            console.log('Vite server shut down successfully!');
+            Logger.info('Vite server shut down successfully!');
         } catch (error) {
-            console.error('Failed to shut down Vite server:', error);
+            Logger.error('Failed to shut down Vite server:', error);
         }
     }
 })
@@ -217,7 +217,7 @@ class BackgroundWorker {
             await worker.update(myConfig);
             worker._watchForParentExit();
         } else {
-            console.log(`Background worker should be running with PID: ${worker.config.pid}`, worker.config);
+            Logger.debug(`Background worker should be running with PID: ${worker.config.pid}`, worker.config);
         }
         return worker;
     }
@@ -229,7 +229,7 @@ class BackgroundWorker {
             if (this._isRunning(this.config.meteorPid)) {
                 return;
             }
-            console.warn('Meteor parent process is no longer running. Shutting down...');
+            Logger.warn('Meteor parent process is no longer running. Shutting down...');
             this.update({
                 pid: 0,
                 meteorPid: 0,
@@ -252,15 +252,15 @@ class BackgroundWorker {
     
     public get isRunning() {
         if (!this.config.pid) {
-            console.log('No background worker process ID')
+            Logger.debug('No background worker process ID')
             return false;
         }
         if (this.config.pid === process.pid) {
-            console.log(`Background worker's process ID is identical to ours`)
+            Logger.debug(`Background worker's process ID is identical to ours`)
             return false;
         }
         if (!this._isRunning(this.config.pid)) {
-            console.warn(`Background worker not running: ${this.config.pid} (current PID ${process.pid}) `);
+            Logger.debug(`Background worker not running: ${this.config.pid} (current PID ${process.pid}) `);
             return false;
         }
         return true;
@@ -273,7 +273,7 @@ class BackgroundWorker {
     
     public async setViteConfig(viteConfig: WorkerRuntimeConfig['viteConfig']) {
         if (this.config.pid !== process.pid && this.isRunning) {
-            console.log(`Skipping Vite config write - config is controlled by different background process: ${this.config.pid}`);
+            Logger.debug(`Skipping Vite config write - config is controlled by different background process: ${this.config.pid}`);
             return;
         }
         await this.update({

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -188,7 +188,14 @@ class BackgroundWorker {
                 return;
             }
             console.warn('Meteor parent process is no longer running. Shutting down...');
-            process.exit(1);
+            this.update({
+                pid: 0,
+                meteorPid: 0,
+                meteorParentPid: 0,
+                viteConfig: {},
+            }).then(() => {
+                process.exit(1);
+            })
         }, 30_000)
     }
     

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -44,6 +44,16 @@ export default CreateIPCInterface({
     // todo: Add reply for triggering a server restart
     async 'vite.startDevServer'(replyInterface: Replies, { packageJson, globalMeteorPackagesDir, meteorParentPid }: DevServerOptions) {
         const worker = await BackgroundWorker.init(meteorParentPid);
+        
+        if (worker.isRunning) {
+            replyInterface({
+                kind: 'viteConfig',
+                data: worker.config.viteConfig,
+            })
+            console.log(`Vite server running as background process. (pid ${worker.config.pid})`);
+            return;
+        }
+        
         const server = await createViteServer({
             packageJson,
             globalMeteorPackagesDir,
@@ -60,15 +70,6 @@ export default CreateIPCInterface({
                 });
             },
         });
-        
-        if (worker.isRunning) {
-            replyInterface({
-                kind: 'viteConfig',
-                data: worker.config.viteConfig,
-            })
-            console.log(`Vite server running as background process. (pid ${worker.config.pid})`);
-            return;
-        }
         
         await server.listen()
         await sendViteConfig(replyInterface);

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -172,18 +172,18 @@ class BackgroundWorker {
         const worker = BackgroundWorker.instance;
         if (!worker.isRunning) {
             await worker.update(myConfig);
+            worker._watchForParentExit();
         } else {
             console.log(`Background worker should be running with PID: ${worker.config.pid}`, worker.config);
         }
         return worker;
     }
-    constructor(public config: WorkerRuntimeConfig) {
-        if (config.pid !== process.pid) {
-            return;
-        }
+    constructor(public config: WorkerRuntimeConfig) {}
+    
+    protected _watchForParentExit() {
         // Keep track of Meteor's parent process to exit if it has ended abruptly.
         setInterval(() => {
-            if (this._isRunning(config.meteorPid)) {
+            if (this._isRunning(this.config.meteorPid)) {
                 return;
             }
             console.warn('Meteor parent process is no longer running. Shutting down...');
@@ -195,7 +195,7 @@ class BackgroundWorker {
             }).then(() => {
                 process.exit(1);
             })
-        }, 5_000)
+        }, 1_000)
     }
     
     protected _isRunning(pid: number) {

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -149,7 +149,7 @@ type WorkerRuntimeConfig = {
 
 class BackgroundWorker {
     public static instance: BackgroundWorker;
-    protected static readonly configPath = '.meteor-vite/vite-server.pid'
+    protected static readonly configPath = Path.join('.meteor-vite', 'vite-server.pid')
     public static async init(meteorParentPid: number) {
         if (BackgroundWorker.instance) {
             return BackgroundWorker.instance;

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -158,7 +158,6 @@ class BackgroundWorker {
         try {
             const content = await FS.readFile(this.configPath, 'utf-8');
             const config = JSON.parse(content);
-            console.log('Retrieved runtime config from file: ', config)
             BackgroundWorker.instance = new BackgroundWorker(config);
         } catch (error) {
             BackgroundWorker.instance = new BackgroundWorker(myConfig)
@@ -167,11 +166,13 @@ class BackgroundWorker {
         const worker = BackgroundWorker.instance;
         if (!worker.isRunning) {
             await worker.update(myConfig);
+        } else {
+            console.log(`Background worker should be running with PID: ${worker.config.pid}`, worker.config);
         }
         return worker;
     }
     constructor(public config: WorkerRuntimeConfig) {
-        console.log('Retrieved background process config', config);
+    
     }
     
     public get isRunning() {
@@ -185,7 +186,6 @@ class BackgroundWorker {
         }
         try {
             process.kill(this.config.pid, 0);
-            console.log('Background worker should be running!');
             return true;
         } catch (error) {
             console.warn(`Background worker not running: ${this.config.pid} (current PID ${process.pid}) `, error);

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -21,7 +21,7 @@ type Replies = IPCReply<{
     data: {},
 } | {
     kind: 'workerConfig';
-    data: WorkerRuntimeConfig;
+    data: WorkerRuntimeConfig & { listening: boolean };
 }>
 
 type ViteRuntimeConfig = {
@@ -235,6 +235,9 @@ async function sendViteConfig(reply: Replies) {
     });
     reply({
         kind: 'workerConfig',
-        data: worker.config,
+        data: {
+            ...worker.config,
+            listening,
+        },
     })
 }

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -76,9 +76,9 @@ export default CreateIPCInterface({
         });
         
         await server.listen()
-        await sendViteConfig(replyInterface);
-        server.printUrls();
         listening = true
+        server.printUrls();
+        await sendViteConfig(replyInterface);
         return;
     },
 

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -54,7 +54,6 @@ export default CreateIPCInterface({
                 kind: 'viteConfig',
                 data: backgroundWorker.config.viteConfig,
             })
-            console.log('Testing testing!');
             console.log(`Vite server running as background process. (pid ${backgroundWorker.config.pid})`);
             return process.exit(0);
         }

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -138,7 +138,6 @@ async function createViteServer({
                         });
                         req.on('end', () => {
                           const message = JSON.parse(body);
-                          console.log(message);
                           MeteorEvents.ingest(message);
                           res.statusCode = 204;
                           next();

--- a/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
+++ b/npm-packages/meteor-vite/src/bin/worker/vite-server.ts
@@ -47,17 +47,16 @@ export default CreateIPCInterface({
     
     // todo: Add reply for triggering a server restart
     async 'vite.startDevServer'(replyInterface: Replies, { packageJson, globalMeteorPackagesDir, meteorParentPid }: DevServerOptions) {
-        const worker = await BackgroundWorker.init(meteorParentPid);
+        const backgroundWorker = await BackgroundWorker.init(meteorParentPid);
         
-        if (worker.isRunning) {
+        if (backgroundWorker.isRunning) {
             replyInterface({
                 kind: 'viteConfig',
-                data: worker.config.viteConfig,
+                data: backgroundWorker.config.viteConfig,
             })
             console.log('Testing testing!');
-            console.log(`Vite server running as background process. (pid ${worker.config.pid})`);
-            process.exit(0);
-            return;
+            console.log(`Vite server running as background process. (pid ${backgroundWorker.config.pid})`);
+            return process.exit(0);
         }
         
         const server = await createViteServer({

--- a/npm-packages/meteor-vite/src/vite/AutoImportQueue.ts
+++ b/npm-packages/meteor-vite/src/vite/AutoImportQueue.ts
@@ -59,7 +59,7 @@ export default new class AutoImportQueue {
         if (this.addedPackages.length > lastPackageCount && !skipRestart) {
             await MeteorEvents.waitForMessage({
                 topic: ['webapp-reload-client', 'client-refresh'],
-                timeoutMs: process.env.NODE_ENV === 'test' ? 50 : 5000, // todo: implement tests for this
+                timeoutMs: process.env.NODE_ENV === 'test' ? 50 : 15_000, // todo: implement tests for this
             }).catch((error: Error) => {
                 if (error instanceof EventTimeout) {
                     Logger.warn(`Timed out waiting for Meteor to refresh the client for ${pc.yellow(importString)}!`)

--- a/npm-packages/meteor-vite/src/vite/ViteLoadRequest.ts
+++ b/npm-packages/meteor-vite/src/vite/ViteLoadRequest.ts
@@ -3,6 +3,7 @@ import FS from 'fs/promises';
 import NodeFS from 'fs';
 import Path from 'path';
 import pc from 'picocolors';
+import { ViteDevServer } from 'vite';
 import { createLabelledLogger, LabelLogger } from '../Logger';
 import { isSameModulePath } from '../meteor/package/components/MeteorPackage';
 import AutoImportQueue from './AutoImportQueue';
@@ -165,6 +166,15 @@ export default class ViteLoadRequest {
         await AutoImportQueue.write({
             meteorEntrypoint: meteorClientEntryFile,
             importString: this.context.id,
+        }).catch((error) => {
+            if (!(error instanceof RefreshNeeded)) {
+                throw error;
+            }
+            if (!this.context.server) {
+                throw error;
+            }
+            
+            this.context.server.restart(true);
         });
     }
     
@@ -197,6 +207,7 @@ export type FileRequestData = ReturnType<typeof ViteLoadRequest['loadFileData']>
 interface PreContextRequest {
     id: string;
     pluginSettings: PluginSettings;
+    server: ViteDevServer;
 }
 
 export interface RequestContext extends PreContextRequest {

--- a/packages/vite-bundler/package.js
+++ b/packages/vite-bundler/package.js
@@ -35,6 +35,7 @@ Package.onUse(function(api) {
   api.use('zodern:types@1.0.9');
   api.use('webapp@1.13.1')
   api.use('typescript@4.0.0')
+  api.use('fetch@0.1.1');
   api.addAssets(['loading/dev-server-splash.html'], 'server');
   api.mainModule('client.ts', 'client');
   api.mainModule('vite-server.ts', 'server')

--- a/packages/vite-bundler/vite-server.ts
+++ b/packages/vite-bundler/vite-server.ts
@@ -34,6 +34,7 @@ if (Meteor.isDevelopment) {
         params: [{
             packageJson: getProjectPackageJson(),
             globalMeteorPackagesDir: meteorPackagePath,
+            meteorParentPid: process.ppid,
         }]
     });
     

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -30,6 +30,7 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>, options?: 
         detached: options?.detached ?? false,
         env: {
             FORCE_COLOR: '3',
+            ENABLE_DEBUG_LOGS: process.env.ENABLE_DEBUG_LOGS,
         },
     });
     

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -50,6 +50,7 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>, options?: 
             console.log('Running Vite worker as a background process..\n  ', [
                 `Background PID: ${pid}`,
                 `Child process PID: ${child.pid}`,
+                `Meteor PID: ${process.pid}`,
                 `Is vite server: ${listening}`,
             ].join('\n   '));
         }

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -46,7 +46,7 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>, options?: 
             workerConfigHook(data);
         }
         const { pid, listening } = data;
-        if (listening) {
+        if (listening && process.env.ENABLE_DEBUG_LOGS) {
             console.log('Running Vite worker as a background process..\n  ', [
                 `Background PID: ${pid}`,
                 `Child process PID: ${child.pid}`,

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -1,4 +1,4 @@
-import { fork } from 'node:child_process'
+import { fork, StdioOptions } from 'node:child_process';
 import { Meteor } from 'meteor/meteor';
 import Path from 'path';
 import FS from 'fs';
@@ -10,7 +10,7 @@ import type { ProjectJson } from '../../npm-packages/meteor-vite/src/vite/plugin
 
 // Use a worker to skip reify and Fibers
 // Use a child process instead of worker to avoid WASM/archived threads error
-export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
+export function createWorkerFork(hooks: Partial<WorkerResponseHooks>, options?: { detached: boolean }) {
     if (!FS.existsSync(workerPath)) {
         throw new MeteorViteError([
                 `Unable to locate Meteor-Vite workers! Make sure you've installed the 'meteor-vite' npm package.`,
@@ -18,11 +18,22 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
                 `$  ${pc.yellow('npm i -D meteor-vite')}`
             ])
     }
+    let stdio: StdioOptions = ['inherit', 'inherit', 'inherit', 'ipc']
+    let shouldKill = true;
+    
+    if (options?.detached) {
+        const logfile = Path.join(cwd, '.meteor-vite/worker.log');
+        FS.mkdirSync(Path.dirname(logfile), { recursive: true });
+        const out = FS.openSync(logfile, 'a');
+        const err = FS.openSync(logfile, 'a');
+        stdio = ['ignore', out, err, 'ipc'];
+        shouldKill = false;
+    }
     
     const child = fork(workerPath, ['--enable-source-maps'], {
-        stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+        stdio,
         cwd,
-        detached: false,
+        detached: options?.detached ?? false,
         env: {
             FORCE_COLOR: '3',
         },
@@ -35,6 +46,25 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
         (hooks[method] as typeof hook) = Meteor.bindEnvironment(hook);
     })
     
+    const workerConfigHook = hooks.workerConfig;
+    hooks.workerConfig = (data) => {
+        if (typeof workerConfigHook === 'function') {
+            workerConfigHook(data);
+        }
+        const { pid, listening } = data;
+        console.log('Running Vite worker as a background process..\n  ', [
+            `Background PID: ${pid}`,
+            `Child process PID: ${child.pid}`,
+            `Is vite server: ${listening}`,
+        ].join('\n   '));
+        
+        if (listening) {
+            shouldKill = false;
+        } else {
+            shouldKill = true;
+        }
+    }
+    
     child.on('message', (message: WorkerResponse & { data: any }) => {
         const hook = hooks[message.kind];
         
@@ -44,15 +74,27 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>) {
         
         return hook(message.data);
     });
+    const disconnect = () => {
+        if (!child.connected) {
+            console.log('Child not connected!');
+            return;
+        }
+        try {
+            child.disconnect();
+            child.unref();
+            console.log('Successfully disconnected from child process!');
+        } catch (error) {
+            console.error('Failure to disconnect', error);
+        }
+    }
     
     ['exit', 'SIGINT', 'SIGHUP', 'SIGTERM'].forEach(event => {
         process.once(event, () => {
-            child.send({
-                method: 'vite.stopDevServer',
-                params: [],
-            } satisfies Omit<WorkerMethod, 'replies'>);
-
-            child.kill()
+            if (!shouldKill) {
+                disconnect();
+                return;
+            }
+            child.kill();
         })
     });
     

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -87,6 +87,7 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>, options?: 
         call(method: Omit<WorkerMethod, 'replies'>) {
             if (!child.connected) {
                 console.warn('Oops worker process is not connected! Tried to send message to worker:', method);
+                console.log('The Vite server is likely running in the background. Try restarting Meteor. 👍');
                 return;
             }
             child.send(method);


### PR DESCRIPTION
Addresses the issue outlined in #35 

The Vite server will be kept as a background process until the Meteor process has closed and should restart independently from Meteor. 