### PR TITLE
Fix syntax error

### DIFF
--- a/packages/vite-bundler/client.ts
+++ b/packages/vite-bundler/client.ts
@@ -58,7 +58,7 @@ function onChange(config: RuntimeConfig) {
     
     if (hasLoadedVite()) {
         DevConnectionLog.info('Attempting to refresh current Vite session to load new server config...')
-        setTimeout(() => window.location.reload(), 1_000);
+        setTimeout(() => window.location.reload(), 1000);
         return;
     }
     


### PR DESCRIPTION
Fix an "Uncaught SyntaxError: Invalid or unexpected token" by restoring a Number type in the second parameter of  `setTimeout`