### PR TITLE
Fix intermittent issue - Assets.getText()

### DIFF
--- a/packages/vite-bundler/loading/vite-connection-handler.ts
+++ b/packages/vite-bundler/loading/vite-connection-handler.ts
@@ -17,8 +17,8 @@ export class ViteDevScripts {
             viteClientUrl: `${baseUrl}/@vite/client`,
         }
     }
-    
-    public async stringTemplate(): Promise<string | Promise<string>> {
+
+    public async stringTemplate(): Promise<string> {
         const { viteClientUrl, entrypointUrl } = this.urls;
         const viteClient = `<script src="${viteClientUrl}" type="module" id="${VITE_CLIENT_SCRIPT_ID}"></script>`;
         const viteEntrypoint = `<script src="${entrypointUrl}" type="module" id="${VITE_ENTRYPOINT_SCRIPT_ID}"></script>`;

--- a/packages/vite-bundler/loading/vite-connection-handler.ts
+++ b/packages/vite-bundler/loading/vite-connection-handler.ts
@@ -18,7 +18,7 @@ export class ViteDevScripts {
         }
     }
     
-    public stringTemplate(): string | Promise<string> {
+    public async stringTemplate(): Promise<string | Promise<string>> {
         const { viteClientUrl, entrypointUrl } = this.urls;
         const viteClient = `<script src="${viteClientUrl}" type="module" id="${VITE_CLIENT_SCRIPT_ID}"></script>`;
         const viteEntrypoint = `<script src="${entrypointUrl}" type="module" id="${VITE_ENTRYPOINT_SCRIPT_ID}"></script>`;
@@ -27,7 +27,7 @@ export class ViteDevScripts {
             return `${viteClient}\n${viteEntrypoint}`;
         }
         
-        return Assets.getText('loading/dev-server-splash.html') as string;
+        return await Assets.getTextAsync('loading/dev-server-splash.html') as string;
     }
     
     public injectScriptsInDOM() {

--- a/packages/vite-bundler/loading/vite-connection-handler.ts
+++ b/packages/vite-bundler/loading/vite-connection-handler.ts
@@ -27,7 +27,7 @@ export class ViteDevScripts {
             return `${viteClient}\n${viteEntrypoint}`;
         }
         
-        return await Assets.getTextAsync('loading/dev-server-splash.html') as string;
+        return await Assets.getTextAsync('loading/dev-server-splash.html');
     }
     
     public injectScriptsInDOM() {

--- a/packages/vite-bundler/types/global.d.ts
+++ b/packages/vite-bundler/types/global.d.ts
@@ -30,6 +30,10 @@ declare global {
         }
         function getDefaultOptions(): CompileOptions;
     }
+    
+    module Assets {
+        function getTextAsync(path: string): Promise<string>;
+    }
 }
 
 export {}


### PR DESCRIPTION
The development mode has an intermittent issue saying that `Assets.getText()` is not a function.
This function was changed to async in Meteor 3.0 and renamed to `Assets.getTextAsync()`.

https://v3-migration-docs.meteor.com/api/renamed-functions.html#assets-gettext