### PR TITLE
Update semver parsing regex

### DIFF
--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -166,7 +166,7 @@ function prepareWorkerEnv() {
 function validateNpmVersion() {
     const packageJson = getProjectPackageJson();
     const version = packageJson.dependencies['meteor-vite'] || packageJson.devDependencies['meteor-vite'];
-    const SEMVER_PARSE_REGEX = /(?<major>\d)+\.(?<minor>\d)+\.(?<patch>\d)+/;
+    const SEMVER_PARSE_REGEX = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/;
     
     if (!version) {
         console.error([


### PR DESCRIPTION
The regex pattern being used to check the version of `meteor-vite` only works as expected for semvers with all single digit components. If the version has a two (or more) digit component, then the effect of the current regex is that only the last digit is returned as part of the match. So, right now the checker is treating version `1.10.4` as `1.0.4`, leading it to incorrectly warn about  using an out of date version.

Fixes #185