### PR TITLE
Update for Meteor 3 final release

### DIFF
--- a/packages/vite-bundler/loading/vite-connection-handler.ts
+++ b/packages/vite-bundler/loading/vite-connection-handler.ts
@@ -18,7 +18,7 @@ export class ViteDevScripts {
         }
     }
     
-    public stringTemplate(): string | Promise<string> {
+    public stringTemplate(): Promise<string> {
         const { viteClientUrl, entrypointUrl } = this.urls;
         const viteClient = `<script src="${viteClientUrl}" type="module" id="${VITE_CLIENT_SCRIPT_ID}"></script>`;
         const viteEntrypoint = `<script src="${entrypointUrl}" type="module" id="${VITE_ENTRYPOINT_SCRIPT_ID}"></script>`;
@@ -27,7 +27,7 @@ export class ViteDevScripts {
             return `${viteClient}\n${viteEntrypoint}`;
         }
         
-        return Assets.getText('loading/dev-server-splash.html') as string;
+        return Assets.getTextAsync('loading/dev-server-splash.html') as string;
     }
     
     public injectScriptsInDOM() {

--- a/packages/vite-bundler/package.js
+++ b/packages/vite-bundler/package.js
@@ -10,7 +10,7 @@ Package.registerBuildPlugin({
     name: 'vite',
     use: [
         'ecmascript@0.16.2 || 1.0.0',
-        'caching-compiler@1.2.2 || 2.0.0-beta300.0',
+        'caching-compiler@1.2.2 || 2.0.0',
         'babel-compiler@7.9.0',
         'typescript@3.0.0 || 4.0.0 || 5.0.0',
     ],
@@ -35,7 +35,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-    api.versionsFrom(['3.0-beta.0', '3.0-rc.0', '3.0-rc.2']);
+    api.versionsFrom(['3.0']);
     api.use([
         'fetch',
         'webapp',
@@ -44,7 +44,7 @@ Package.onUse(function (api) {
         'isobuild:compiler-plugin@1.0.0',
     ]);
     api.use([
-        'zodern:types@1.0.9',
+        'zodern:types@1.0.13',
     ], {
         weak: true,
     });


### PR DESCRIPTION
Update versions for the final release of Meteor 3 and fix `Assets.getText` to `Assets.getTextAsync` as `Assets.getText` is no longer available in Meteor 3.