### PR TITLE
Add example usage for `zodern:relay` to Meteor v3 example app.

### DIFF
--- a/.babel-plugin/changelog.md
+++ b/.babel-plugin/changelog.md
@@ -1,0 +1,7 @@
+## 1.1.4 - October 25, 2023
+
+- Fix running on Windows
+
+## 1.1.3 - January 25, 2023
+
+- Fix error when class is exported (@banjerluke)

--- a/.babel-plugin/package-lock.json
+++ b/.babel-plugin/package-lock.json
@@ -1,0 +1,1095 @@
+{
+  "name": "@zodern/babel-plugin-meteor-relay",
+  "version": "1.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.18.6"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
+      "integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
+      "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.10",
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-module-transforms": "^7.18.9",
+        "@babel/helpers": "^7.18.9",
+        "@babel/parser": "^7.18.10",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.18.10",
+        "@babel/types": "^7.18.10",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.1",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.10",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+      "integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.18.8",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.20.2",
+        "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
+    },
+    "@babel/helper-function-name": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+      "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.9"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+      "integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
+      "integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+      "integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.18.6",
+        "@babel/traverse": "^7.18.9",
+        "@babel/types": "^7.18.9"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.18.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
+      "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
+      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.10",
+        "@babel/types": "^7.18.10"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.18.11",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
+      "integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.10",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.11",
+        "@babel/types": "^7.18.10",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
+      "integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.18.10",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "browserslist": {
+      "version": "4.21.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001370",
+        "electron-to-chromium": "^1.4.202",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.5"
+      }
+    },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001377",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001377.tgz",
+      "integrity": "sha512-I5XeHI1x/mRSGl96LFOaSk528LA/yZG3m3iQgImGujjO8gotd/DL8QaI1R1h1dg5ATeI2jqPblMpKq4Tr5iKfQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.4.221",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.221.tgz",
+      "integrity": "sha512-aWg2mYhpxZ6Q6Xvyk7B2ziBca4YqrCDlXzmcD7wuRs65pVEVkMT1u2ifdjpAQais2O2o0rW964ZWWWYRlAL/kw==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^2.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
+      }
+    },
+    "mocha": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "update-browserslist-db": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    }
+  }
+}

--- a/.babel-plugin/package.json
+++ b/.babel-plugin/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@zodern/babel-plugin-meteor-relay",
+  "version": "1.1.4",
+  "description": "Babel plugin to use with zodern:relay",
+  "main": "plugin.js",
+  "scripts": {
+    "test": "mocha ./test"
+  },
+  "author": "zodern",
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": "^7.18.10",
+    "mocha": "^10.0.0"
+  }
+}

--- a/.babel-plugin/plugin.js
+++ b/.babel-plugin/plugin.js
@@ -1,0 +1,445 @@
+const { createHash } = require('crypto');
+const path = require('path');
+
+// If has a MemberExpression, returns the first call expression in its callee
+// Otherwise, returns the call expression
+function getFirstCallExpr(call) {
+  if (call.node.callee.type !== 'MemberExpression') {
+    return call;
+  }
+
+
+  if (
+    call.node.callee.object.type !== 'CallExpression'
+  ) {
+    return;
+  }
+
+  return call.get('callee.object');
+}
+
+module.exports = function (api) {
+  let t = api.types;
+
+  let caller;
+  api.caller(function (c) {
+    caller = c;
+  });
+
+  function createExport(exportName, callee, name, stub) {
+    let args = [
+      t.StringLiteral(name)
+    ];
+
+    if (stub) {
+      if (stub.type === 'ObjectMethod') {
+        stub = t.FunctionExpression(
+          null,
+          stub.node.params || [],
+          stub.node.body,
+          stub.node.generator,
+          stub.node.async
+        )
+      } else if (stub.type === 'ObjectProperty') {
+        stub = stub.node.value;
+      }
+      args.push(stub);
+    }
+
+    const declaration = t.CallExpression(
+      t.Identifier(callee),
+      args
+    );
+
+    if (exportName === null) {
+      return t.ExportDefaultDeclaration(
+        declaration
+      );
+    }
+
+    return t.ExportNamedDeclaration(
+      t.VariableDeclaration(
+        'const',
+        [t.VariableDeclarator(
+          t.Identifier(exportName),
+          declaration
+        )]
+      )
+    )
+  }
+
+  function getOrAddName(args, { exportName, filePath, isPub }) {
+    if (args[0].type !== 'ObjectExpression') {
+      return;
+    }
+
+    let obj = args[0];
+    let nameProperty = obj.properties.find((property) => {
+      if (property.key.type !== 'Identifier') {
+        return false;
+      }
+
+      if (property.key.name !== 'name') {
+        return false;
+      }
+
+      return property.value.type === 'StringLiteral';
+    });
+
+    if (nameProperty) {
+      return nameProperty.value.value;
+    }
+
+    let fileHash = 'M' + createHash('sha256')
+      .update(filePath)
+      .digest('hex')
+      .substring(0, 5);
+
+    let name = exportName;
+
+    if (name === null) {
+      let baseName = path.basename(filePath);
+      let lastDotIndex = baseName.lastIndexOf('.');
+      name = baseName.substring(0, lastDotIndex);
+    } else if (isPub && name.startsWith('subscribe')) {
+      name = exportName.substring('subscribe'.length);
+
+      if (name[0] !== name[0].toLowerCase()) {
+        name = `${name[0].toLowerCase()}${name.substring(1)}`
+      }
+    }
+
+    name += fileHash;
+
+    obj.properties.push(t.ObjectProperty(
+      t.Identifier('name'),
+      t.StringLiteral(name)
+    ));
+
+    return name;
+  }
+
+  // TODO: args should be a path instead of node
+  function findStubPropertyIndex(args) {
+    let obj = args[0];
+    let stubPropIndex = obj.properties.findIndex((property) => {
+      if (property.key.type !== 'Identifier') {
+        return false;
+      }
+
+      if (property.key.name !== 'stub') {
+        return false;
+      }
+
+      return true;
+    });
+    let stub = obj.properties[stubPropIndex];
+
+    if (!stub) {
+      return -1;
+    }
+
+    if (
+       stub.type === 'ObjectMethod' ||
+      stub.value.type === 'FunctionExpression' ||
+      stub.value.type === 'ArrowFunctionExpression'
+    ) {
+      return stubPropIndex;
+    }
+
+
+    if (stub.value.type !== 'BooleanLiteral') {
+      return -1;
+    }
+
+    if (stub.value.value !== true) {
+      return -1;
+    }
+
+    // stub is set to true - use the run function
+    return obj.properties.findIndex((property) => {
+      if (property.key.type !== 'Identifier') {
+        return false;
+      }
+
+      if (property.key.name !== 'run') {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  let canHaveMethods = false;
+  let canHavePublications = false;
+  let createMethodName = null;
+  let createPublicationName = null;
+  let methods = [];
+  let publications = [];
+  let isServer = false;
+  let filePath = ''
+  let imports = Object.create(null);
+
+  return {
+    visitor: {
+      Program: {
+        enter(_, state) {
+          createMethodName = null;
+          createPublicationName = null;
+          methods = [];
+          publications = [];
+
+          let relPath = path
+            .relative(state.cwd, state.filename)
+            .split(path.sep)
+            .join(path.posix.sep);
+          filePath = relPath;
+
+          canHaveMethods = relPath.includes('/methods/') || relPath.startsWith('methods/');
+          canHavePublications = relPath.includes('/publications/') || relPath.startsWith('publications/');
+
+          isServer = caller.arch.startsWith('os.');
+
+          if (!canHaveMethods && !canHavePublications) {
+            return;
+          }
+        },
+        exit(path) {
+          if (isServer || !canHaveMethods && !canHavePublications) {
+            return;
+          }
+
+          if (methods.length === 0 && publications.length === 0) {
+            path.node.body = [];
+            return;
+          }
+
+          let body = [];
+
+          let importSpecifiers = [];
+          if (methods.length > 0) {
+            importSpecifiers.push(
+              t.ImportSpecifier(t.Identifier('_createClientMethod'), t.Identifier('_createClientMethod'))
+            );
+          }
+          if (publications.length > 0) {
+            importSpecifiers.push(
+              t.ImportSpecifier(t.Identifier('_createClientPublication'), t.Identifier('_createClientPublication'))
+            )
+          }
+
+          let importDecl = t.ImportDeclaration(
+            importSpecifiers,
+            t.StringLiteral('meteor/zodern:relay/client'),
+          );
+
+          body.push(importDecl);
+
+          methods.forEach(method => {
+            if (method.stub) {
+              let stubBody = method.stub.get('body').node ?
+                method.stub.get('body') : method.stub.get('value.body');
+              stubBody.traverse({
+                ReferencedIdentifier(subPath) {
+                  if (stubBody.scope.hasOwnBinding(subPath.node.name)) {
+                    return;
+                  }
+
+                  if (subPath.node.name in imports) {
+                    let importDesc = imports[subPath.node.name];
+
+                    let specifier;
+                    if (importDesc.type === 'ImportDefaultSpecifier') {
+                      specifier = t.ImportDefaultSpecifier(t.Identifier(subPath.node.name));
+                    } else if (importDesc.type === 'ImportNamespaceSpecifier') {
+                      specifier = t.ImportNamespaceSpecifier(t.Identifier(subPath.node.name));
+                    } else {
+                      specifier = t.ImportSpecifier(
+                        t.Identifier(importDesc.importName),
+                        t.Identifier(subPath.node.name)
+                      );
+                    }
+
+                    // TODO: we should preserve the original order of the imports
+                    body.push(t.ImportDeclaration(
+                      [ specifier ],
+                      t.StringLiteral(importDesc.source)
+                    ));
+                  }
+                }
+              });
+            }
+
+            body.push(
+              createExport(method.export, '_createClientMethod', method.name, method.stub)
+            );
+          });
+
+          publications.forEach(publication => {
+            body.push(
+              createExport(publication.export, '_createClientPublication', publication.name)
+            );
+          });
+
+          path.node.body = body;
+
+          return;
+        },
+      },
+      ImportDeclaration(path) {
+        path.node.specifiers.forEach(specifier => {
+          let type = specifier.type;
+          let hasImportName = type !== 'ImportDefaultSpecifier' &&
+            type !== 'ImportNamespaceSpecifier'
+          imports[specifier.local.name] = {
+            type,
+            importName: hasImportName ?
+              specifier.imported.name :
+              null,
+            source: path.node.source.value
+          };
+
+          if (!hasImportName) {
+            return;
+          }
+
+          if (canHaveMethods && specifier.imported.name === 'createMethod') {
+            createMethodName = specifier.local.name;
+          }
+          if (canHavePublications && specifier.imported.name === 'createPublication') {
+            createPublicationName = specifier.local.name;
+          }
+        });
+      },
+      ExportDefaultDeclaration(path) {
+        if (path.node.declaration.type !== 'CallExpression') {
+          return;
+        }
+
+        let call = getFirstCallExpr(path.get('declaration'));
+
+        if (!call) {
+          return;
+        }
+
+        if (
+          call.node.callee.name === createMethodName
+        ) {
+          let name = getOrAddName(call.node.arguments, {
+            exportName: null,
+            filePath,
+            isPub: false
+          });
+          if (name === undefined) {
+            throw new Error('Unable to find name for createMethod');
+          }
+          let stubPropIndex = findStubPropertyIndex(call.node.arguments);
+          let stub;
+          if (stubPropIndex > -1) {
+            stub = call.get(`arguments.0.properties.${stubPropIndex}`);
+          }
+
+          methods.push({
+            name: name,
+            export: null,
+            stub
+          });
+        }
+
+        if (
+          call.node.callee.name === createPublicationName
+        ) {
+          let name = getOrAddName(call.node.arguments, {
+            exportName: null,
+            filePath,
+            isPub: true
+          });
+          if (name === undefined) {
+            throw new Error('Unable to find name for createMethod');
+          }
+
+          publications.push({
+            name: name,
+            export: null
+          });
+        }
+      },
+      ExportNamedDeclaration(path) {
+        let declaration = path.get('declaration');
+
+        if (
+          // null when the code is something like "export { h };"
+          !declaration.node ||
+          declaration.isFunctionDeclaration()
+        ) {
+          return;
+        }
+
+        if (declaration.type == 'ClassDeclaration') {
+          return;
+        }
+
+        if (declaration.type !== 'VariableDeclaration') {
+          throw new Error(`export declarations of type ${declaration.type} are not supported`);
+        }
+
+        declaration.get('declarations').forEach(vDeclaration => {
+          if (!vDeclaration.isVariableDeclarator()) {
+            throw new Error(`Unsupported declaration type in VariableDeclaration: ${vDeclaration.node.type}`);
+          }
+
+          if (!vDeclaration.get('init').isCallExpression()) {
+            return;
+          }
+
+          let call = getFirstCallExpr(vDeclaration.get('init'));
+
+          if (!call) {
+            return;
+          }
+
+          if (
+            call.node.callee.name === createMethodName
+          ) {
+            let name = getOrAddName(call.node.arguments, {
+              exportName: vDeclaration.node.id.name,
+              filePath,
+              isPub: false
+            });
+            if (name === undefined) {
+              throw new Error('Unable to find name for createMethod');
+            }
+            let stubPropIndex = findStubPropertyIndex(call.node.arguments);
+            let stub;
+            if (stubPropIndex > -1) {
+              stub = call.get(`arguments.0.properties.${stubPropIndex}`);
+            }
+            methods.push({
+              name: name,
+              export: vDeclaration.node.id.name,
+              stub
+            });
+          }
+
+          if (
+            call.node.callee.name === createPublicationName
+          ) {
+            let name = getOrAddName(call.node.arguments, {
+              exportName: vDeclaration.node.id.name,
+              filePath,
+              isPub: true
+            });
+            if (name === undefined) {
+              throw new Error('Unable to find name for createMethod');
+            }
+
+            publications.push({
+              name: name,
+              export: vDeclaration.node.id.name
+            });
+          }
+        })
+      }
+    }
+  };
+}

--- a/.babel-plugin/readme.md
+++ b/.babel-plugin/readme.md
@@ -1,0 +1,17 @@
+## @zodern/babel-plugin-meteor-relay
+
+Babel plugin to use with `zodern:relay`. Handles rewriting files in `methods` and `publications` directories.
+
+To use:
+```
+npm install @zodern/babel-plugin-meteor-relay
+```
+
+Create a `.babelrc` file for your Meteor app:
+```
+{
+  "plugins": [
+    "@zodern/babel-plugin-meteor-relay"
+  ]
+}
+```

--- a/.babel-plugin/test/test.js
+++ b/.babel-plugin/test/test.js
@@ -1,0 +1,372 @@
+const assert = require('assert');
+const path = require('path');
+
+const transform = (str, filename = '/methods/index.js', arch = 'web.browser') => {
+  return require('@babel/core').transform(str, {
+    plugins: ['./plugin.js'],
+    caller: {
+      name: 'meteor',
+      arch
+    },
+    filename
+  }).code;
+};
+
+describe('Plugin', () => {
+  it('should make file empty on client', () => {
+    const code = 'const example = "Hello";';
+    assert.equal(transform(code), '');
+  });
+
+  it('should ignore various types of exports', () => {
+    const code = `
+      export const a = true;
+      export let b = true;
+      export var c = true;
+      export function d () {
+
+      }
+
+      export class A {}
+
+      let h = true;
+      export { h };
+    `;
+    assert.equal(transform(code), '');
+  });
+
+  describe('methods', () => {
+    it('should leave code as is on the server', () => {
+      const code = `
+import { createMethod } from 'meteor/zodern:relay';
+export default createMethod({
+  name: 'myMethod'
+});
+      `;
+      assert.equal(transform(code, '/methods/index.js', 'os.osx.x86_64'), code.trim());
+    });
+    it('should add missing names on the server', () => {
+      const code = `
+import { createMethod } from 'meteor/zodern:relay';
+export const createProject = createMethod({
+});
+export default createMethod({
+  
+});
+      `;
+      const expected = `
+import { createMethod } from 'meteor/zodern:relay';
+export const createProject = createMethod({
+  name: "createProjectM000bd"
+});
+export default createMethod({
+  name: "projectsM000bd"
+});
+      `;
+      assert.equal(transform(code, '/methods/projects.js', 'os.osx.x86_64'), expected.trim());
+    });
+
+    it('should add missing names on the client', () => {
+      const code = `
+import { createMethod } from 'meteor/zodern:relay';
+export const createProject = createMethod({
+});
+export default createMethod({
+  
+});
+      `;
+      const expected = `
+import { _createClientMethod } from "meteor/zodern:relay/client";
+export const createProject = _createClientMethod("createProjectM000bd");
+export default _createClientMethod("projectsM000bd");
+      `;
+      assert.equal(transform(code, '/methods/projects.js'), expected.trim());
+    });
+
+    it('should work in top level methods folders', () => {
+      const code = `
+import { createMethod } from 'meteor/zodern:relay';
+export const createProject = createMethod({
+});
+export default createMethod({
+  
+});
+      `;
+      const expected = `
+import { _createClientMethod } from "meteor/zodern:relay/client";
+export const createProject = _createClientMethod("createProjectM169f1");
+export default _createClientMethod("projectsM169f1");
+      `;
+      assert.equal(transform(code, path.resolve(__dirname, '../methods/projects.js')), expected.trim());
+    });
+
+    it('should handle default exports', () => {
+      const code = `
+        import { createMethod } from 'meteor/zodern:relay';
+        export default createMethod({
+          name: 'myMethod'
+        });
+      `;
+      assert.equal(transform(code), `
+import { _createClientMethod } from "meteor/zodern:relay/client";
+export default _createClientMethod("myMethod");
+      `.trim());
+    });
+
+    it('should handle named exports', () => {
+      const code = `
+        import { createMethod } from 'meteor/zodern:relay';
+        export const myMethod = createMethod({ name: 'myMethod' });
+      `;
+      assert.equal(transform(code), `
+import { _createClientMethod } from "meteor/zodern:relay/client";
+export const myMethod = _createClientMethod("myMethod");
+      `.trim());
+    });
+
+    it('should handle pipelines', () => {
+      const code = `
+        import { createMethod } from 'meteor/zodern:relay';
+        export const myMethod = createMethod({ name: 'myMethod' })
+          .pipeline(() => 5, (i) => i + 10);
+
+        export default createMethod({ name: 'method2' }).pipeline(() => 5);
+      `
+
+      assert.equal(transform(code), `
+import { _createClientMethod } from "meteor/zodern:relay/client";
+export const myMethod = _createClientMethod("myMethod");
+export default _createClientMethod("method2");
+      `.trim());
+    });
+
+    it('should handle exporting member expressions', () => {
+      const code = `
+        import { createMethod } from 'meteor/zodern:relay';
+        export const schema = z.number();
+        export default z.string();
+      `
+
+      assert.equal(transform(code), '');
+    });
+
+    describe('stubs', () => {
+      it('should use run function as stub', () => {
+        const code = `
+        import assert from 'assert';
+        import * as n from './namespace';
+        import { createMethod } from 'meteor/zodern:relay';
+        import { generate } from '../generate';
+
+        export const myMethod = createMethod({
+          name: 'myMethod',
+          stub: true,
+          run(b) {
+            generate();
+            let a = 10;
+            return 5 + a;
+          }
+        });
+
+        export default createMethod({
+          name: 'myMethod',
+          stub: true,
+          run: (b) => {
+            generate();
+            assert.equals(10, 10);
+          }
+        });
+      `
+
+        assert.equal(transform(code), `
+        import { _createClientMethod } from "meteor/zodern:relay/client";
+import { generate } from "../generate";
+export const myMethod = _createClientMethod("myMethod", function (b) {
+  generate();
+  let a = 10;
+  return 5 + a;
+});
+import { generate } from "../generate";
+import assert from "assert";
+export default _createClientMethod("myMethod", b => {
+  generate();
+  assert.equals(10, 10);
+});
+      `.trim());
+      });
+
+      it('should use stub function as stub', () => {
+        const code = `
+        import assert from 'assert';
+        import { createMethod } from 'meteor/zodern:relay';
+        import { generate } from '../generate';
+        import * as n from './namespace';
+
+        export const myMethod = createMethod({
+          name: 'myMethod',
+          stub(b) {
+            n.b();
+            generate();
+            let a = 10;
+            return 5 + a;
+          },
+          run() {}
+        });
+
+        export default createMethod({
+          name: 'myMethod',
+          stub: (b) => {
+            generate();
+            assert.equals(10, 10);
+          },
+          run() {}
+        });
+      `
+
+        assert.equal(transform(code), `
+        import { _createClientMethod } from "meteor/zodern:relay/client";
+import * as n from "./namespace";
+import { generate } from "../generate";
+export const myMethod = _createClientMethod("myMethod", function (b) {
+  n.b();
+  generate();
+  let a = 10;
+  return 5 + a;
+});
+import { generate } from "../generate";
+import assert from "assert";
+export default _createClientMethod("myMethod", b => {
+  generate();
+  assert.equals(10, 10);
+});
+      `.trim());
+      });
+    });
+  });
+
+  describe('subscriptions', () => {
+    it('should handle default exports', () => {
+      const code = `
+        import { createPublication } from 'meteor/zodern:relay';
+        export default createPublication({ name: 'myPublication' });
+      `;
+      assert.equal(transform(code, '/publications/index.js'), `
+import { _createClientPublication } from "meteor/zodern:relay/client";
+export default _createClientPublication("myPublication");
+      `.trim());
+    });
+
+    it('should handle publications folder in the app root', () => {
+      const code = `
+        import { createPublication } from 'meteor/zodern:relay';
+        export const myPublication = createPublication({ name: 'myPublication' });
+      `;
+      assert.equal(transform(code, path.resolve(__dirname, '../publications/index.js')), `
+import { _createClientPublication } from "meteor/zodern:relay/client";
+export const myPublication = _createClientPublication("myPublication");
+      `.trim());
+    });
+    it('should handle named exports', () => {
+      const code = `
+        import { createPublication } from 'meteor/zodern:relay';
+        export const myPublication = createPublication({ name: 'myPublication' });
+      `;
+      assert.equal(transform(code, '/publications/index.js'), `
+import { _createClientPublication } from "meteor/zodern:relay/client";
+export const myPublication = _createClientPublication("myPublication");
+      `.trim());
+    });
+
+    it('should handle pipelines', () => {
+      const code = `
+        import { createPublication } from 'meteor/zodern:relay';
+        export const sub1 = createPublication({ name: 'pub1' })
+          .pipeline(() => []);
+
+        export default createPublication({ name: 'pub2' }).pipeline(() => []);
+      `
+
+      assert.equal(transform(code, '/publications/index.js'), `
+import { _createClientPublication } from "meteor/zodern:relay/client";
+export const sub1 = _createClientPublication("pub1");
+export default _createClientPublication("pub2");
+      `.trim());
+    });
+
+    it('should add missing names', () => {
+      const code = `
+        import { createPublication } from 'meteor/zodern:relay';
+        export const subscribeProjects = createPublication({ })
+          .pipeline(() => []);
+
+        export default createPublication({ });
+      `
+
+      assert.equal(transform(code, '/publications/index.js'), `
+import { _createClientPublication } from "meteor/zodern:relay/client";
+export const subscribeProjects = _createClientPublication("projectsM2962a");
+export default _createClientPublication("indexM2962a");
+      `.trim());
+    });
+  });
+
+  describe('wrongFolder', () => {
+    it('should handle unsupported export types', () => {
+      const code = `
+        export function a() {};
+      `
+
+      transform(code, '/index.js');
+    })
+    it('should leave methods as is outside of methods folder', () => {
+      const code = `
+import { createMethod } from 'meteor/zodern:relay';
+export default createMethod({
+  name: 'myMethod'
+});
+      `;
+      assert.equal(transform(code, '/index.js'), code.trim());
+    });
+    it('should leave publications as is outside of publications folder', () => {
+      const code = `
+import { createPublication } from 'meteor/zodern:relay';
+export default createPublication({
+  name: 'myMethod'
+});
+      `;
+      assert.equal(transform(code, '/index.js'), code.trim());
+    });
+
+    it('should ignore publications in methods folder', () => {
+      const code = `
+import { createPublication, createMethod } from 'meteor/zodern:relay';
+export default createPublication({
+  name: 'myPublication'
+});
+export const a = createMethod({
+  name: 'other-method'
+});
+      `;
+      assert.equal(transform(code, '/methods/index.js'), `
+import { _createClientMethod } from "meteor/zodern:relay/client";
+export const a = _createClientMethod("other-method");
+`.trim());
+    })
+
+    it('should ignore methods in publications folder', () => {
+      const code = `
+import { createPublication, createMethod } from 'meteor/zodern:relay';
+export default createPublication({
+  name: 'myPub'
+});
+export const a = createMethod({
+  name: 'other-method'
+});
+      `;
+      assert.equal(transform(code, '/publications/index.js'), `
+import { _createClientPublication } from "meteor/zodern:relay/client";
+export default _createClientPublication("myPub");
+`.trim());
+    })
+  });
+});

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -133,6 +133,8 @@ linkNpmPackage() {
 
   (cd "$packageDir" && $npm link) || exit 1
   (cd "$APP_DIR" && $npm link "$packageName") || exit 1
+
+  log:success "Linked $packageName"
 }
 
 link() {
@@ -155,6 +157,22 @@ production:app() {
   export MONGO_URL="$PROD_MONGO_CONNECTION_URI"
 
   $node main.js
+}
+
+log() {
+  set +x
+  local title="$1"
+  local content="${@:2}"
+  echo "
+
+  [--  $title  --]
+  L $content
+  "
+  set -x
+}
+
+log:success() {
+  log Success "$@"
 }
 
 # Alias for exec:meteor

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -62,6 +62,11 @@ install() {
   $npm i "$@"
 }
 
+exec:meteor() {
+  cd "$APP_DIR" || exit 1
+  meteor "$@"
+}
+
 # Initial setup for example apps - installs and links our local packages.
 prepare() {
   $npm run install:package
@@ -152,6 +157,11 @@ production:app() {
 
   $node main.js
 }
+
+# Alias for exec:meteor
+if [ "$action" == "meteor" ]; then
+  action="exec:meteor"
+fi
 
 set -x
 "$action" "${@:3}" || exit 1

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -67,6 +67,11 @@ exec:meteor() {
   meteor "$@"
 }
 
+exec:npm() {
+  cd "$APP_DIR" || exit 1
+  $npm "$@"
+}
+
 # Initial setup for example apps - installs and links our local packages.
 prepare() {
   $npm run install:package
@@ -175,10 +180,12 @@ log:success() {
   log Success "$@"
 }
 
-# Alias for exec:meteor
-if [ "$action" == "meteor" ]; then
-  action="exec:meteor"
-fi
+# Alias commands to their respective functions
+for command in "meteor" "npm"; do
+    if [ "$action" == "$command" ]; then
+        action="exec"
+    fi
+done
 
 set -x
 "$action" "${@:3}" || exit 1

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -128,12 +128,11 @@ cleanOutput() {
 }
 
 linkNpmPackage() {
-  set -e
   local packageDir="$PWD/npm-packages/$1"
   local packageName="${2:-$1}"
 
-  cd "$packageDir" && $npm link
-  cd "$APP_DIR" && $npm link "$packageName"
+  (cd "$packageDir" && $npm link) || exit 1
+  (cd "$APP_DIR" && $npm link "$packageName") || exit 1
 }
 
 link() {

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -21,7 +21,6 @@ node="meteor node"
 EXAMPLE_DIR="$PWD/examples"
 APP_DIR="$EXAMPLE_DIR/$app"
 BUILD_TARGET="$PWD/examples/output/$app"
-NPM_LINK_TARGET="$PWD/npm-packages/meteor-vite"
 METEOR_LOCAL_DIR_ORIGINAL="$APP_DIR/.meteor/local"
 METEOR_LOCAL_DIR_ROOT="/tmp/.meteor-local/meteor-vite/examples"
 METEOR_LOCAL_DIR="$METEOR_LOCAL_DIR_ROOT/$app"
@@ -125,7 +124,8 @@ cleanOutput() {
 
 link() {
   cd "$APP_DIR" || exit 1
-  $npm link "$NPM_LINK_TARGET"
+  $npm link "$PWD/npm-packages/meteor-vite"
+  $npm link "$PWD/npm-packages/zodern-relay"
 }
 
 production:install() {

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -122,10 +122,19 @@ cleanOutput() {
   rm -rf "$BUILD_TARGET"
 }
 
+linkNpmPackage() {
+  set -e
+  local packageDir="$PWD/npm-packages/$1"
+  local packageName="${2:-$1}"
+
+  cd "$packageDir" && $npm link
+  cd "$APP_DIR" && $npm link "$packageName"
+}
+
 link() {
-  cd "$APP_DIR" || exit 1
-  $npm link "$PWD/npm-packages/meteor-vite"
-  $npm link "$PWD/npm-packages/zodern-relay"
+  set -e
+  linkNpmPackage meteor-vite
+  linkNpmPackage zodern-relay '@meteor-vite/plugin-zodern-relay'
 }
 
 production:install() {

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -72,6 +72,11 @@ exec:npm() {
   $npm "$@"
 }
 
+exec:npx() {
+  cd "$APP_DIR" || exit 1
+  npx "$@"
+}
+
 # Initial setup for example apps - installs and links our local packages.
 prepare() {
   $npm run install:package
@@ -181,9 +186,9 @@ log:success() {
 }
 
 # Alias commands to their respective functions
-for command in "meteor" "npm"; do
+for command in "meteor" "npm" "npx"; do
     if [ "$action" == "$command" ]; then
-        action="exec"
+        action="exec:$command"
     fi
 done
 

--- a/.changeset/early-fans-play.md
+++ b/.changeset/early-fans-play.md
@@ -1,0 +1,5 @@
+---
+"@meteor-vite/plugin-zodern-relay": patch
+---
+
+Include Babel Typescript preset in transformer plugin.

--- a/.changeset/heavy-comics-raise.md
+++ b/.changeset/heavy-comics-raise.md
@@ -2,8 +2,11 @@
 "vite-bundler": patch
 ---
 
-Use in-memory collection for MeteorVite connection info
+- Use in-memory collection for MeteorVite connection info
+- Supply default caller arguments during Babel transpilation step for production
+
 
 #### Fixes
 - https://github.com/JorgenVatle/meteor-vite/issues/187
 - https://github.com/JorgenVatle/meteor-vite/issues/186
+- https://github.com/JorgenVatle/meteor-vite/issues/182

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,467 @@
+# zodern:relay - Type safe Meteor methods and publications
+
+zodern:relay allows you to easily write methods and publications, and have typescript check the types of the args and result wherever you call the method or subscribe to a publication.
+
+#### /imports/methods/projects.ts:
+```ts
+import { createMethod } from 'meteor/zodern:relay';
+import { z } from 'zod';
+import { Projects } from '/shared/collections';
+
+export const createProject = createMethod({
+  schema: z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    isPublic: z.boolean(),
+  }),
+  run({ name, description, isPublic }): string {
+    let id = Projects.insert({
+      name,
+
+      // Type 'string | undefined' is not assignable to type 'string'.
+      //   Type 'undefined' is not assignable to type 'string'.ts(2322)
+      description,
+      public: isPublic,
+    });
+
+    return id;
+  },
+});
+
+```
+
+#### /client/exampleProject.ts
+```ts
+import { createProject } from '/imports/methods/projects';
+
+export async function createExampleProject() {
+  // id has type of string
+  const id = await createProject({
+    // Property 'isPublic' is missing in type '{ name: string; }'
+    // but required in type
+    // '{ description?: string | undefined; name: string; isPublic: boolean; }'.ts(2345)
+    name: 'Example',
+  });
+}
+
+```
+
+You might be wondering if this can expose server code on the client. None of the content of files in `methods` or `publications` directories are used on the client. If any of these files are imported on the client, their content is completely replaced. On the client, the files will export small functions for calling any methods or subscribing to any publications that were originally exported by the file.
+
+## Getting started
+
+1. Install `zodern:relay` and [`zod`](https://www.npmjs.com/package/zod)
+
+```
+meteor add zodern:relay
+meteor npm install zod
+```
+
+2. Set up `@zodern/babel-plugin-meteor-relay`
+
+```
+meteor npm install @zodern/babel-plugin-meteor-relay
+```
+
+Create a `.babelrc` in the root of your Meteor app:
+
+```json
+{
+  "plugins": [
+    "@zodern/babel-plugin-meteor-relay"
+  ]
+}
+```
+
+3. Set up `zodern:types`
+
+If you haven't already, add [`zodern:types`](https://atmospherejs.com/zodern/types) to your app so typescript can use the type definitions from `zodern:relay`.
+
+## Methods
+
+You can define methods in files in `methods` directories. The `methods` directories should not be inside a `client` or `server` folder so you can import the methods on both the client and server. The babel plugin will replace the content of these files when imported on the client, so you don't have to worry about server code being exposed.
+
+```ts
+import { createMethod } from 'meteor/zodern:relay';
+import { z } from 'zod';
+
+export const add = createMethod({
+  name: 'add',
+  schema: z.number().array().length(2),
+  run([a, b]) {
+    return a + b;
+  },
+});
+```
+
+`schema` is always required, and must be a schema created from the `zod` npm package. If the method does not have any arguments, you can use `zod.undefined()` as the schema. If you do not want to check the arguments, you can use `zod.any()`.
+
+The schema is used to provide types for for the `run` function's parameter, and to check the arguments when calling the method.
+
+The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name.
+
+`createMethod` returns a function you can use to call the method. The function returns a promise that resolves with the result. The result will have the same type as the return value of the `run` function.
+
+```ts
+import { add } from '/imports/methods/add'
+
+add([1, 2]).then(result => {
+  console.log(result) // logs 3
+});
+```
+
+The method name, schema, or run function, are available on the `config` property of the function returned by `createMethod`:
+
+```ts
+import { add } from '/imports/methods/add';
+
+
+console.log(
+  add.config.name,
+  add.config.schema,
+  add.config.run
+)
+```
+
+On the client, only `config.name` is defined.
+
+## Publications
+
+You can define publications in files in `publications` directories. The `publications` directories should not be inside a `client` or `server` folder so you can import the publications on both the client and server. The babel plugin will replace the content of these files when imported on the client, so you don't have to worry about server code being exposed.
+
+```ts
+import { createPublication } from 'meteor/zodern:relay';
+import { z } from 'zod';
+import { Projects } from '/collections';
+
+export const subscribeProject = createPublication({
+  name: 'project',
+  schema: z.object({
+    id: z.string()
+  }),
+  run({ id }) {
+    return Projects.find({ _id: id });
+  },
+});
+```
+
+`schema` is always required, and must be a schema created from the `zod` npm package. If the method does not have any arguments, you can use `zod.undefined()` as the schema. If you do not want to check the arguments, you can use `zod.any()`.
+
+The schema is used to provide types for for the `run` function's parameter, and to check the arguments when subscribing to the publication.
+
+The `name` is optional. If it is not provided, the babel plugin will add one based on the export name and file name.
+
+`createPublication` returns a function you can use to subscribe to the publication. This function returns a [Subscription Handle](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe), the same as `Meteor.subscribe` would.
+
+```ts
+import { subscribeProject } from '/imports/publications/projects'
+
+const exampleId = 'example';
+
+subscribeProject({ id: exampleId });
+
+subscribeProject({ id: exampleId }, {
+  onStop(err) {
+    console.log('subscription stopped', err);
+  },
+  onReady() {
+    console.log('subscription ready');
+  }
+});
+```
+
+Like with methods, the function returned by `createPublication` has a `config` property to access the name, schema, and run function. On the client, only the name is available.
+
+## Blocking
+
+By default, methods and publications will [block](https://guide.meteor.com/methods.html#methods-vs-rest), meaning each session will run one method or publication at a time, in the order the client calls or subscribes. In cases where you do not want this behavior for a specific method or subscription, you can call `this.unblock()`.
+
+Meteor has a bug for methods and publications with an async function where they will always be unblocked, and there is no way to have them block. `zodern:relay` fixes this so async methods and publications are consistent with Meteor's normal behavior.
+
+## Rate limiting
+
+Both `createMethod` and `createPublication` support a `rateLimit` option:
+```ts
+export const add = createMethod({
+  name: 'add',
+  schema: z.number().array().length(2),
+  rateLimit: {
+    interval: 2000,
+    limit: 10
+  },
+  run([a, b]) {
+    return a + b;
+  },
+});
+```
+
+`interval` is the number of ms before the rate limit is reset. `limit` is the maximum number of method calls or created subscriptions allowed per time interval.
+
+## Pipelines
+
+Instead of defining a single run function, a pipeline allows you to use an array of functions as a pipe. The output of each function is then used as the input of the next function. For example:
+
+```ts
+export const getTasks = createMethod({
+  name: 'getTasks',
+  schema: z.object({
+    tag: z.string().optional()
+    status: z.string().optional(),
+  })
+}).pipeline(
+  (input) => ({ ...input, status: input.status || 'new' }),
+  pickOrganization,
+  ({ tag, status, organizationId }) => {
+    return Tasks.find({ organizationId, status, tag }).fetch();
+  }
+);
+```
+
+Pipelines are configured by calling the `pipeline` function returned by `createMethod`. The `pipeline` function is only available when `run` function is not configured.
+
+Each argument passed to the `pipeline` function is a step in the pipeline. This method has 3 steps in the pipeline. The first step takes the data sent from the client, and then returns an object with the status set to a default value. The next step takes that as the input, and then adds an `organizationId` property. The final step uses the completed input, and returns some documents from the database. Since this is the last step, its return value is sent to the client.
+
+Benefits of pipelines:
+- Allows you to break complicated methods and publications into multiple steps
+- Types for the input are automatically inferred through the pipeline
+- Composable: you can create functions that are used in the pipelines for many methods or publications. You can even create partial pipelines - groups of pipeline steps you can then add to pipelines while maintaining their types
+- Reactive Publications: steps of the pipeline can optionally re-run when data in the database changes, allowing you to then change what cursors are published
+- You can define global pipeline steps that run before and after every method or publication
+
+### Re-usable pipeline steps
+
+With js, you can simply create a function that returns the input for the next step:
+```js
+function pipelineStep(input) {
+  // Do work...
+
+
+  return input;
+}
+```
+
+With typescript, you have to write it as a generic function so typescript can track the types in the pipeline:
+```ts
+function pipelineStep<T>(input: T) {
+  // Do work...
+
+  return input;
+}
+
+// Expects the input to have a projectId property
+// Typescript will validate that the previous pipeline step returned an object
+// with projectId
+function pipelineStep<T extends { projectId: string }>(input: T) {
+  let projectId = input;
+  
+  // Do work...
+
+  return input;
+}
+```
+
+If you are using the same group of pipeline steps for multiple methods or publications, you can create partial pipelines. Partial pipelines are created using the `partialPipeline` function:
+
+```ts
+import { partialPipeline } from 'meteor/zodern:relay';
+
+let adminPipeline = partialPipeline(
+  requireAdmin,
+  unblock,
+  auditAdmin
+);
+
+export const listUsers = createMethod({
+  name: 'listUsers',
+  schema: z.undefined()
+}).pipeline(
+  (input) => input,
+  adminPipeline,
+  () => Users.find().fetch();
+);
+```
+
+For typescript to infer the types correctly in reusable steps or partial pipelines, they can not be used as the first step in the pipeline. As in the example above, you can have the first step be a simple function that returns the input. This then allows typescript to correctly infer the return type of `adminPipeline`.
+
+### Pipeline step arguments
+
+Each step in the pipeline is passed two arguments:
+1. The output from the previous step. If the first step, it is given the initial data
+2. The pipeline object.
+
+The pipeline object has a number of useful functions and properties:
+- `originalInput` the data given to the first step of the pipeline
+- `type` either `method` or `publication`
+- `name` the name of the method or publication
+- `onResult` Pass `onResult` a callback to run when the method or publication finishes. The callback is given the final result. Please note that the callback should not modify the result.
+- `onError` Pass `onError` a callback to run when the method or publication errors. If you want to change the error, the callback can return an error that should be used instead
+- `stop` calling this will stop a publication's pipeline - the current step will finish, but subsequent steps will not run. This will also mark the subscription as ready. `stop` currently can not be used with methods.
+
+Here is an example of a re-usable pipeline step that logs the results of methods
+
+```ts
+function logResult (input, pipeline) {
+  if (pipeline.type === 'publication') {
+    return;
+  }
+
+  pipeline.onResult((result) => {
+    console.log(`Method ${pipeline.name} finished`);
+    console.log('Result', result);
+  });
+
+  pipeline.onError((err) => {
+    console.log(`Method ${pipeline.name} failed`);
+    console.log('Error', err);
+  });
+}
+
+```
+
+### Global Pipeline
+
+If you have a step you want to run before or after every method or publication, you can configure the global pipeline. Please note that the global pipeline should return the input unmodified. Any modifications will not be reflected in the types.
+
+```ts
+import { setGlobalMethodPipeline, setGlobalPublicationPipeline } from 'meteor/zodern:relay';
+
+setGlobalMethodPipeline(
+  auditMethods,
+  logStatus
+);
+
+setGlobalPublicationPipeline(
+  auditPublications,
+  logStatus
+);
+```
+
+### Reactive Publication Pipelines
+
+Reactive pipelines allows steps of the pipeline to re-run when the results of a Mongo cursor change. This is useful for reactive joins, reacting to changes in permissions, and other use cases.
+
+The function `withCursors` allows the pipeline to watch for changes in the database:
+
+```js
+function pipelineStep(input) {
+  let cursor = Projects.find({ owner: Meteor.userId(), organization: input.organization });
+
+  return withCursors(input, { projects: cursor });
+}
+```
+
+`withCursors` accepts two arguments. The first one is the input for the next step. The second argument is an object with the Mongo queries to watch. The two objects are merged together, with the cursors being replaced with the cursor results. In the above example, the input for the next step will have a new `projects` property with the value being the results of the cursor.
+
+When the results of any of the cursors change, the input for the next step will be updated and the pipeline will be re-run starting at the next step.
+
+Here is a complete example:
+
+```ts
+createMethod({
+  name: 'allTasks',
+  schema: z.object({
+    organization: z.string()
+  }),
+}).pipeline(
+  (input) => {
+    let cursor = Projects.find({ owner: Meteor.userId(), organization: input.organization });
+
+    return withCursors(input, { projects: cursor });
+  },
+  (input) => {
+    let projectIds = input.projects.map(project => project._id);
+
+    return Tasks.find({ project: { $in: projectIds } });
+  }
+);
+```
+
+The first step of the pipeline creates a cursor to find all projects the user owns. This cursor is passed in the second object to `withCursors`, with the key `projects`.
+
+The input of the second step has a new property named `projects`, matching what the key for the cursor. The `projects` property has an array of all the docs found by the cursor.
+
+Whenever the results of the cursor change (maybe the user deleted a project or created a new one), the second step of the pipeline is re-run, with the `projects` property having the new list of docs. This allows it to replace the query being published to use the current list of projects.
+
+Here is an example showing reacting to permission changes:
+
+```ts
+createMethod({
+  name: 'adminListUsers',
+  schema: z.undefined()
+}).pipeline(
+  (input) => {
+    const user = Meteor.users.find({_id: Meteor.userId()});
+
+    return withCursors(input, { user })
+  },
+  (input) => {
+    const [ user ] = input.user;
+
+    if (user.isAdmin) {
+      return Users.find().fetch();
+    }
+
+    return [];
+  }
+);
+```
+
+The first step of the pipeline creates a cursor to get the doc for the current user. The second step then uses the doc to check if the user is an admin to decide if it should publish the data. If the user's doc is later modified so they are no longer an admin, the second step of the pipeline will then re-run, allowing it to stop publishing any data.
+
+
+## Method Stubs
+
+By default, no code you write in `methods` directories will be kept on the client. However, you can mark specific methods that you want to also use as stubs on the client. In this case, `zodern:relay` only keeps two pieces of code on the client:
+
+- The stub function itself 
+- The specific imports used by the stub function
+
+To re-use the`run` function for a method as the stub on the client, you can set the `stub` option to `true`.
+
+```ts
+import { Tasks } from '/collections';
+import { createMethod } from 'meteor/zodern:relay';
+
+export const createTask = createMethod({
+  schema: z.string(),
+  stub: true,
+  run(name) {
+    Tasks.insert({ name, owner: Meteor.userId() });
+  }
+});
+```
+
+To use a different method for the stub, configure it using the `stop` property:
+
+```ts
+import { Tasks, Events } from '/collections';
+import { createMethod } from 'meteor/zodern:relay';
+
+export const createTask = createMethod({
+  schema: z.string(),
+  stub() {
+    Tasks.insert({ name, owner: Meteor.userId() });
+  },
+  run(name) {
+    checkPermissions(Meteor.userId());
+    Tasks.insert({ name, owner: Meteor.userId() });
+    sendEmail();
+    Events.insert({ type: 'task.add', user: Meteor.userId() })
+  }
+});
+```
+
+In the above example, only the stub function would be kept on the client:
+```ts
+  stub() {
+    Tasks.insert({ name, owner: Meteor.userId() });
+  }
+```
+
+Since this function uses the imported `Tasks`, that import will also be kept on the client:
+
+```ts
+import { Tasks } from '/collections';
+```
+
+> At this time, stubs are not supported for methods that use pipelines

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,7 @@
+The changelog for the babel plugin is at [.babel-plugin/changelog.md](./.babel-plugin/changelog.md);
+This is the changelog for the `zodern:relay` Meteor package.
+
+## 1.1.1 - May 10, 2023
+
+- Export PipelineContext type
+- Fix types for Apps that do not use @types/meteor

--- a/client-main.ts
+++ b/client-main.ts
@@ -1,0 +1,13 @@
+function createError(funcName: string, folder: string) {
+  throw new Error(`${funcName} should never be called on the client.
+Ensure you have @zodern/babel-plugin-meteor-reify configured, or
+you are calling ${funcName} only in files inside a ${folder} directory`);
+}
+
+export function createMethod() {
+  throw createError('createMethod', 'methods');
+}
+
+export function createPublication() {
+  throw createError('createPublication', 'publications');
+}

--- a/client.ts
+++ b/client.ts
@@ -1,0 +1,42 @@
+export function _createClientMethod(name: string, stub: Function) {
+  if (stub) {
+    Meteor.methods({
+      [name]: stub as any
+    });
+  }
+
+  function call(args: any) {
+    return new Promise((resolve, reject) => {
+      Meteor.apply(
+        name,
+        args === undefined ? [] : [args],
+        {},
+        (err: any, result: any) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(result);
+          }
+        }
+      );
+    });
+  }
+
+  call.config = { name };
+
+  return call;
+}
+
+export function _createClientPublication(name: string | null) {
+  function subscribe(...args: any) {
+    if (name === null) {
+      throw new Error('Cannot directly subscribe to null publication');
+    }
+
+    return Meteor.subscribe(name, ...args);
+  }
+
+  subscribe.config = { name };
+
+  return subscribe;
+}

--- a/examples/meteor-v3-vue/.babelrc
+++ b/examples/meteor-v3-vue/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "@zodern/babel-plugin-meteor-relay"
+  ]
+}

--- a/examples/meteor-v3-vue/.meteor/packages
+++ b/examples/meteor-v3-vue/.meteor/packages
@@ -10,11 +10,11 @@ standard-minifier-css@1.9.3   # CSS minifier run for production mode
 standard-minifier-js@3.0.0    # JS minifier run for production mode
 es5-shim@4.8.1                # ECMAScript 5 compatibility for older browsers
 ecmascript@0.16.9              # Enable ECMAScript2015+ syntax in app code
-typescript@5.4.3              # Enable TypeScript syntax in .ts and .tsx modules
 shell-server@0.6.0            # Server-side component of the `meteor shell` command
 webapp@2.0.0                  # Serves a Meteor app over HTTP
 server-render@0.4.2           # Support for server-side rendering
 hot-module-replacement@0.5.4  # Rebuilds the client if there is a change on the client without restarting the server
 mongo@2.0.0
 
-jorgenvatle:vite-bundler@2.0.1
+jorgenvatle:vite-bundler
+zodern:relay

--- a/examples/meteor-v3-vue/.meteor/packages
+++ b/examples/meteor-v3-vue/.meteor/packages
@@ -18,3 +18,4 @@ mongo@2.0.0
 
 jorgenvatle:vite-bundler
 zodern:relay
+typescript

--- a/examples/meteor-v3-vue/.meteor/versions
+++ b/examples/meteor-v3-vue/.meteor/versions
@@ -14,6 +14,7 @@ core-runtime@1.0.0
 ddp@1.4.2
 ddp-client@3.0.0
 ddp-common@1.4.3
+ddp-rate-limiter@1.2.2
 ddp-server@3.0.0
 diff-sequence@1.1.3
 dynamic-import@0.7.4
@@ -32,7 +33,7 @@ html-tools@2.0.0-alpha300.17
 htmljs@2.0.0-alpha300.17
 id-map@1.2.0
 inter-process-messaging@0.1.2
-jorgenvatle:vite-bundler@2.0.1
+jorgenvatle:vite-bundler@2.0.2
 logging@1.3.5
 meteor@2.0.0
 minifier-css@2.0.0
@@ -50,6 +51,7 @@ npm-mongo@4.17.3
 ordered-dict@1.2.0
 promise@1.0.0
 random@1.2.2
+rate-limit@1.1.2
 react-fast-refresh@0.2.9
 reload@1.3.2
 retry@1.1.1
@@ -67,3 +69,5 @@ typescript@5.4.3
 underscore@1.6.4
 webapp@2.0.0
 webapp-hashing@1.1.2
+zodern:relay@1.1.1
+zodern:types@1.0.13

--- a/examples/meteor-v3-vue/client/main.css
+++ b/examples/meteor-v3-vue/client/main.css
@@ -1,4 +1,0 @@
-body {
-  padding: 10px;
-  font-family: sans-serif;
-}

--- a/examples/meteor-v3-vue/client/main.html
+++ b/examples/meteor-v3-vue/client/main.html
@@ -2,7 +2,6 @@
   <title>Minimal Meteor app</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/logo.svg">
-  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
 
 <body>

--- a/examples/meteor-v3-vue/client/main.html
+++ b/examples/meteor-v3-vue/client/main.html
@@ -5,7 +5,7 @@
 </head>
 
 <body>
-  <main class="prose">
+  <main class="prose container mx-auto py-4 lg:py-8 xl:py-12">
     <h1>Minimal Meteor app</h1>
     <p>
       This Meteor app uses as few Meteor packages as possible, to keep the

--- a/examples/meteor-v3-vue/client/main.html
+++ b/examples/meteor-v3-vue/client/main.html
@@ -2,24 +2,27 @@
   <title>Minimal Meteor app</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/logo.svg">
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
 </head>
 
 <body>
-  <h1>Minimal Meteor app</h1>
-  <p>
-    This Meteor app uses as few Meteor packages as possible, to keep the
-    client JavaScript bundle as small as possible.
-  </p>
+  <main class="prose">
+    <h1>Minimal Meteor app</h1>
+    <p>
+      This Meteor app uses as few Meteor packages as possible, to keep the
+      client JavaScript bundle as small as possible.
+    </p>
 
-  <em id="server-render-target"></em>
+    <em id="server-render-target"></em>
 
-  <h2>Learn Meteor!</h2>
-  <ul>
-    <li><a href="https://www.meteor.com/try" target="_blank">Do the Tutorial</a></li>
-    <li><a href="http://guide.meteor.com" target="_blank">Follow the Guide</a></li>
-    <li><a href="https://docs.meteor.com" target="_blank">Read the Docs</a></li>
-    <li><a href="https://forums.meteor.com" target="_blank">Discussions</a></li>
-  </ul>
+    <h2>Learn Meteor!</h2>
+    <ul>
+      <li><a href="https://www.meteor.com/try" target="_blank">Do the Tutorial</a></li>
+      <li><a href="http://guide.meteor.com" target="_blank">Follow the Guide</a></li>
+      <li><a href="https://docs.meteor.com" target="_blank">Read the Docs</a></li>
+      <li><a href="https://forums.meteor.com" target="_blank">Discussions</a></li>
+    </ul>
 
-  <div id="vue-app"></div>
+    <div id="vue-app"></div>
+  </main>
 </body>

--- a/examples/meteor-v3-vue/client/main.js
+++ b/examples/meteor-v3-vue/client/main.js
@@ -1,1 +1,12 @@
+/**
+ * These modules are automatically imported by jorgenvatle:vite-bundler.
+ * You can commit these to your project or move them elsewhere if you'd like,
+ * but they must be imported somewhere in your Meteor entrypoint file.
+ *
+ * More info: https://github.com/JorgenVatle/meteor-vite#lazy-loaded-meteor-packages
+**/
+import 'meteor/zodern:relay';
+import 'meteor/zodern:relay/client';
+/** End of vite-bundler auto-imports **/
+
 console.log(`Greetings from ${module.id}!`);

--- a/examples/meteor-v3-vue/imports/api/chat/collection.ts
+++ b/examples/meteor-v3-vue/imports/api/chat/collection.ts
@@ -1,9 +1,16 @@
 import { Mongo } from 'meteor/mongo';
+import { z } from 'zod';
 
 export const ChatCollection = new Mongo.Collection<ChatDocument, ChatDocument>('chat');
 
-export interface ChatDocument {
+export interface ChatDocument extends z.infer<typeof ChatSchema> {
     _id: string;
-    content: string;
-    createdAt: Date;
 }
+
+export const ChatSchema = z.object({
+    content: z.string().max(1024),
+    createdAt: z.date(),
+    user: z.object({
+        name: z.string().max(100),
+    }),
+});

--- a/examples/meteor-v3-vue/imports/api/chat/collection.ts
+++ b/examples/meteor-v3-vue/imports/api/chat/collection.ts
@@ -1,6 +1,6 @@
 import { Mongo } from 'meteor/mongo';
 
-export const ChatCollection = new Mongo.Collection<ChatDocument>('chat');
+export const ChatCollection = new Mongo.Collection<ChatDocument, ChatDocument>('chat');
 
 export interface ChatDocument {
     _id: string;

--- a/examples/meteor-v3-vue/imports/api/chat/collection.ts
+++ b/examples/meteor-v3-vue/imports/api/chat/collection.ts
@@ -1,0 +1,9 @@
+import { Mongo } from 'meteor/mongo';
+
+export const ChatCollection = new Mongo.Collection<ChatDocument>('chat');
+
+export interface ChatDocument {
+    _id: string;
+    content: string;
+    createdAt: Date;
+}

--- a/examples/meteor-v3-vue/imports/api/chat/methods.ts
+++ b/examples/meteor-v3-vue/imports/api/chat/methods.ts
@@ -1,0 +1,16 @@
+import { createMethod } from 'meteor/zodern:relay';
+import { z } from 'zod';
+import { ChatCollection } from './collection';
+
+export const sendMessage = createMethod({
+    name: 'sendMessage',
+    schema: z.object({
+        content: z.string(),
+    }),
+    run({ content }) {
+        return ChatCollection.insertAsync({
+            content,
+            createdAt: new Date(),
+        });
+    }
+});

--- a/examples/meteor-v3-vue/imports/api/chat/publications.ts
+++ b/examples/meteor-v3-vue/imports/api/chat/publications.ts
@@ -1,0 +1,19 @@
+import { createPublication } from 'meteor/zodern:relay';
+import * as z from 'zod';
+import { ChatCollection } from './collection';
+
+export const subscribeToChat = createPublication({
+    name: 'chat',
+    schema: z.object({
+        query: z.object({}),
+        options: z.object({
+            limit: z.number().optional(),
+            sort: z.object({
+                createdAt: z.number().optional(),
+            }).optional(),
+        }).optional(),
+    }),
+    run({ query, options }) {
+        return ChatCollection.find(query, options);
+    }
+});

--- a/examples/meteor-v3-vue/imports/api/links/links.collection.ts
+++ b/examples/meteor-v3-vue/imports/api/links/links.collection.ts
@@ -1,7 +1,7 @@
 import { Mongo } from 'meteor/mongo';
 import * as Valibot from 'valibot';
 
-export default new Mongo.Collection<LinkDocument>('links');
+export default new Mongo.Collection<LinkDocument, LinkDocument>('links');
 
 export const LinkSchema = Valibot.object({
     url: Valibot.string([Valibot.maxLength(512)]),

--- a/examples/meteor-v3-vue/imports/api/relay/methods/chat.ts
+++ b/examples/meteor-v3-vue/imports/api/relay/methods/chat.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { createMethod } from 'meteor/zodern:relay';
 import { z } from 'zod';
 import { ChatCollection } from '../../chat/collection';
@@ -12,5 +13,13 @@ export const sendMessage = createMethod({
             content,
             createdAt: new Date(),
         });
+    }
+});
+
+export const generateUsername = createMethod({
+    name: 'generateUsername',
+    schema: z.undefined(),
+    run() {
+        return faker.internet.userName();
     }
 });

--- a/examples/meteor-v3-vue/imports/api/relay/methods/chat.ts
+++ b/examples/meteor-v3-vue/imports/api/relay/methods/chat.ts
@@ -1,6 +1,6 @@
 import { createMethod } from 'meteor/zodern:relay';
 import { z } from 'zod';
-import { ChatCollection } from './collection';
+import { ChatCollection } from '../../chat/collection';
 
 export const sendMessage = createMethod({
     name: 'sendMessage',

--- a/examples/meteor-v3-vue/imports/api/relay/methods/chat.ts
+++ b/examples/meteor-v3-vue/imports/api/relay/methods/chat.ts
@@ -1,16 +1,14 @@
 import { faker } from '@faker-js/faker';
 import { createMethod } from 'meteor/zodern:relay';
 import { z } from 'zod';
-import { ChatCollection } from '../../chat/collection';
+import { ChatCollection, ChatSchema } from '../../chat/collection';
 
 export const sendMessage = createMethod({
     name: 'sendMessage',
-    schema: z.object({
-        content: z.string(),
-    }),
-    run({ content }) {
+    schema: ChatSchema.pick({ content: true, user: true }),
+    run(message) {
         return ChatCollection.insertAsync({
-            content,
+            ...message,
             createdAt: new Date(),
         });
     }

--- a/examples/meteor-v3-vue/imports/api/relay/publications/chat.ts
+++ b/examples/meteor-v3-vue/imports/api/relay/publications/chat.ts
@@ -1,6 +1,6 @@
 import { createPublication } from 'meteor/zodern:relay';
 import * as z from 'zod';
-import { ChatCollection } from './collection';
+import { ChatCollection } from '../../chat/collection';
 
 export const subscribeToChat = createPublication({
     name: 'chat',

--- a/examples/meteor-v3-vue/imports/entrypoint/vite-client.ts
+++ b/examples/meteor-v3-vue/imports/entrypoint/vite-client.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue';
 import AppComponent from '../ui/App.vue';
+import '../ui/App.css';
 
 const App = createApp(AppComponent);
 

--- a/examples/meteor-v3-vue/imports/ui/App.css
+++ b/examples/meteor-v3-vue/imports/ui/App.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/examples/meteor-v3-vue/imports/ui/App.css
+++ b/examples/meteor-v3-vue/imports/ui/App.css
@@ -1,3 +1,21 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    body {
+        @apply container
+    }
+
+    input {
+        @apply border p-2 rounded;
+    }
+
+    button {
+        @apply bg-emerald-400 inline-flex items-center justify-center text-white p-2 rounded outline-none border-none text-sm font-bold px-5 text-center;
+    }
+
+    label {
+        @apply font-medium;
+    }
+}

--- a/examples/meteor-v3-vue/imports/ui/App.css
+++ b/examples/meteor-v3-vue/imports/ui/App.css
@@ -2,11 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-    body {
-        @apply container
-    }
-
+.prose {
     input {
         @apply border py-1 px-2 rounded font-normal;
     }

--- a/examples/meteor-v3-vue/imports/ui/App.css
+++ b/examples/meteor-v3-vue/imports/ui/App.css
@@ -8,7 +8,7 @@
     }
 
     input {
-        @apply border p-2 rounded;
+        @apply border py-1 px-2 rounded font-normal;
     }
 
     button {

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -1,21 +1,21 @@
 <template>
   <div>
     <h2>Hello from Vue!</h2>
-    <div>
+    <div class="pb-8">
       <h3>Vue links</h3>
       <ul>
         <li v-for="{ title, url } in links">
           <a :href="url">{{ title }}</a>
         </li>
       </ul>
-      <form @submit.prevent="linkForm.create()" class="flex gap-6">
-        <label class="w-1/3">
+      <form @submit.prevent="linkForm.create()" class="flex gap-2">
+        <label class="flex-grow">
           <span class="block">Title</span>
-          <input v-model="linkForm.data.title" placeholder="Something important">
+          <input class="w-full" v-model="linkForm.data.title" placeholder="Something important">
         </label>
-        <label class="w-1/3">
+        <label class="flex-grow">
           <span class="block">URL</span>
-          <input v-model="linkForm.data.url" placeholder="https://example.com/...">
+          <input class="w-full" v-model="linkForm.data.url" placeholder="https://example.com/...">
         </label>
         <button type="submit" class="place-self-end">
           Submit
@@ -27,8 +27,8 @@
       <div>
 
       </div>
-      <div>
-        <input type="text" placeholder="Type your message here">
+      <div class="flex gap-2">
+        <input class="w-full" type="text" placeholder="Type your message here">
         <button>Send</button>
       </div>
     </div>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -30,13 +30,13 @@
       <p>
         Uses <code>zodern:relay</code> to load and send messages.
       </p>
-      <div>
+      <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64">
 
       </div>
-      <div class="flex gap-2">
+      <form class="flex gap-2">
         <input class="w-full" type="text" placeholder="Type your message here">
         <button>Send</button>
-      </div>
+      </form>
     </div>
   </div>
 </template>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -9,7 +9,7 @@
     <section>
       <h3>Vue links</h3>
       <p>
-        Uses <code>meteor-type-validation</code> for schema validation and method/publication type inference.
+        Uses your standard Meteor methods and publications to render content.
       </p>
       <ul>
         <li v-for="{ title, url } in links.data">

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -53,6 +53,7 @@
 <script lang="ts" setup>
 import { reactive, ref } from 'vue';
 import type { ChatDocument } from '../api/chat/collection';
+import { sendMessage } from '../api/chat/methods';
 import LinksCollection, { LinkDocument } from '../api/links/links.collection';
 import { Tracker } from 'meteor/tracker';
 import { Meteor } from 'meteor/meteor';
@@ -73,10 +74,10 @@ const chat = reactive({
     data: [] as ChatDocument[],
     ready: false,
     form: {
-        message: '',
+        content: '',
     },
     async send() {
-        await Meteor.callAsync('chat.send', chat.form);
+        await sendMessage(chat.form);
     },
 });
 

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -39,7 +39,7 @@
       <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64">
         <div v-for="message in chat.data">
           <div>{{ message.content || '(no content)' }}</div>
-          <div class="text-sm text-gray-500">{{ message.createdAt }}</div>
+          <div class="text-sm text-gray-500">{{ formatRelativeTime(message.createdAt) }}</div>
         </div>
       </div>
       <form class="flex gap-2" @submit.prevent="chat.send()">
@@ -58,6 +58,7 @@ import { Tracker } from 'meteor/tracker';
 import { Meteor } from 'meteor/meteor';
 import { sendMessage } from '../api/relay/methods/chat';
 import { subscribeToChat } from '../api/relay/publications/chat';
+import { formatRelativeTime } from './composition/Helpers';
 
 const links = reactive({
     data: [] as LinkDocument[],

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -79,6 +79,7 @@ const chat = reactive({
     },
     async send() {
         await sendMessage(chat.form);
+        chat.form.content = '';
     },
 });
 

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -36,10 +36,12 @@
       <p>
         Uses <code>zodern:relay</code> to load and send messages.
       </p>
-      <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64 max-h-96 overflow-y-auto">
-        <div v-for="message in chat.data">
-          <div>{{ message.content || '(no content)' }}</div>
-          <div class="text-sm text-gray-500">{{ formatRelativeTime(message.createdAt) }}</div>
+      <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64 max-h-96 overflow-y-auto grid gap-3">
+        <div v-for="message in chat.data" class="bg-emerald-500 rounded-md p-4">
+          <div class="text-white font-medium">{{ message.content || '(no content)' }}</div>
+          <div class="flex justify-end">
+            <div class="text-sm text-white/80">{{ formatRelativeTime(message.createdAt) }}</div>
+          </div>
         </div>
       </div>
       <form class="flex gap-2" @submit.prevent="chat.send()">

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -8,19 +8,29 @@
           <a :href="url">{{ title }}</a>
         </li>
       </ul>
-      <form @submit.prevent="linkForm.create()">
-        <label>
-          Link Title
+      <form @submit.prevent="linkForm.create()" class="flex gap-6">
+        <label class="w-1/3">
+          <span class="block">Title</span>
           <input v-model="linkForm.data.title" placeholder="Something important">
         </label>
-        <label>
-          URL
+        <label class="w-1/3">
+          <span class="block">URL</span>
           <input v-model="linkForm.data.url" placeholder="https://example.com/...">
         </label>
-        <button type="submit">
+        <button type="submit" class="place-self-end">
           Submit
         </button>
       </form>
+    </div>
+    <div>
+      <h3>Vue Chat</h3>
+      <div>
+
+      </div>
+      <div>
+        <input type="text" placeholder="Type your message here">
+        <button>Send</button>
+      </div>
     </div>
   </div>
 </template>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -89,7 +89,9 @@ Tracker.autorun(() => {
 });
 
 Tracker.autorun(() => {
-    const subscription = subscribeToChat();
+    const subscription = subscribeToChat({
+        query: {},
+    });
     chat.ready = subscription.ready();
     chat.data = ChatCollection.find({}).fetch();
 })

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -12,18 +12,18 @@
         Uses <code>meteor-type-validation</code> for schema validation and method/publication type inference.
       </p>
       <ul>
-        <li v-for="{ title, url } in links">
+        <li v-for="{ title, url } in links.data">
           <a :href="url">{{ title }}</a>
         </li>
       </ul>
-      <form @submit.prevent="linkForm.create()" class="flex gap-2">
+      <form @submit.prevent="links.create()" class="flex gap-2">
         <label class="flex-grow">
           <span class="block">Title</span>
-          <input class="w-full" v-model="linkForm.data.title" placeholder="Something important">
+          <input class="w-full" v-model="links.form.title" placeholder="Something important">
         </label>
         <label class="flex-grow">
           <span class="block">URL</span>
-          <input class="w-full" v-model="linkForm.data.url" placeholder="https://example.com/...">
+          <input class="w-full" v-model="links.form.url" placeholder="https://example.com/...">
         </label>
         <button type="submit" class="place-self-end">
           Submit
@@ -53,20 +53,21 @@ import LinksCollection, { LinkDocument } from '../api/links/links.collection';
 import { Tracker } from 'meteor/tracker';
 import { Meteor } from 'meteor/meteor';
 
-const links = ref<LinkDocument[]>([]);
-const ready = ref(false);
-const linkForm = reactive({
-    data: {
-      title: '',
-      url: '',
+const links = reactive({
+    data: [] as LinkDocument[],
+    ready: false,
+    form: {
+        title: '',
+        url: '',
     },
     async create() {
-        await Meteor.callAsync('links.create', linkForm.data);
-    }
-})
+        await Meteor.callAsync('links.create', links.form);
+    },
+});
+
 Tracker.autorun(() => {
     const subscription = Meteor.subscribe('links');
-    ready.value = subscription.ready();
-    links.value = LinksCollection.find({}).fetch();
+    links.ready = subscription.ready();
+    links.data = LinksCollection.find({}).fetch();
 });
 </script>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -36,7 +36,7 @@
       <p>
         Uses <code>zodern:relay</code> to load and send messages.
       </p>
-      <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64">
+      <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64 max-h-96 overflow-y-auto">
         <div v-for="message in chat.data">
           <div>{{ message.content || '(no content)' }}</div>
           <div class="text-sm text-gray-500">{{ formatRelativeTime(message.createdAt) }}</div>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -3,6 +3,9 @@
     <h2>Hello from Vue!</h2>
     <div class="pb-8">
       <h3>Vue links</h3>
+      <p>
+        Uses <code>meteor-type-validation</code> for schema validation and method/publication type inference.
+      </p>
       <ul>
         <li v-for="{ title, url } in links">
           <a :href="url">{{ title }}</a>
@@ -24,6 +27,9 @@
     </div>
     <div>
       <h3>Vue Chat</h3>
+      <p>
+        Uses <code>zodern:relay</code> to load and send messages.
+      </p>
       <div>
 
       </div>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -61,6 +61,7 @@ import { Meteor } from 'meteor/meteor';
 import { sendMessage } from '../api/relay/methods/chat';
 import { subscribeToChat } from '../api/relay/publications/chat';
 import { formatRelativeTime } from './composition/Helpers';
+import { CurrentUser } from './GlobalState';
 
 const links = reactive({
     data: [] as LinkDocument[],
@@ -79,6 +80,7 @@ const chat = reactive({
     ready: false,
     form: {
         content: '',
+        user: CurrentUser,
     },
     async send() {
         await sendMessage(chat.form);

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -39,8 +39,9 @@
       <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64 max-h-96 overflow-y-auto grid gap-3">
         <div v-for="message in chat.data" class="bg-emerald-500 rounded-md p-4">
           <div class="text-white font-medium">{{ message.content || '(no content)' }}</div>
-          <div class="flex justify-end">
-            <div class="text-sm text-white/80">{{ formatRelativeTime(message.createdAt) }}</div>
+          <div class="flex justify-between text-sm text-white/80">
+            <div>{{ message.user?.name || 'Anonymous user' }}</div>
+            <div>{{ formatRelativeTime(message.createdAt) }}</div>
           </div>
         </div>
       </div>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -53,11 +53,11 @@
 <script lang="ts" setup>
 import { reactive, ref } from 'vue';
 import { ChatCollection, type ChatDocument } from '../api/chat/collection';
-import { sendMessage } from '../api/chat/methods';
-import { subscribeToChat } from '../api/chat/publications';
 import LinksCollection, { LinkDocument } from '../api/links/links.collection';
 import { Tracker } from 'meteor/tracker';
 import { Meteor } from 'meteor/meteor';
+import { sendMessage } from '../api/relay/methods/chat';
+import { subscribeToChat } from '../api/relay/publications/chat';
 
 const links = reactive({
     data: [] as LinkDocument[],

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <h2>Hello from Vue!</h2>
+    <h2>Vue App</h2>
+    <p>
+      The following content is rendered entirely by Vite's <b>Vue</b> plugin.
+    </p>
     <div class="pb-8">
       <h3>Vue links</h3>
       <p>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -38,7 +38,7 @@
       </p>
       <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64">
         <div v-for="message in chat.data">
-          <div>{{ message.content }}</div>
+          <div>{{ message.content || '(no content)' }}</div>
           <div class="text-sm text-gray-500">{{ message.createdAt }}</div>
         </div>
       </div>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -4,7 +4,9 @@
     <p>
       The following content is rendered entirely by Vite's <b>Vue</b> plugin.
     </p>
-    <div class="pb-8">
+  </div>
+  <div class="divide-y-2 flex flex-col gap-12">
+    <section>
       <h3>Vue links</h3>
       <p>
         Uses <code>meteor-type-validation</code> for schema validation and method/publication type inference.
@@ -27,8 +29,9 @@
           Submit
         </button>
       </form>
-    </div>
-    <div>
+    </section>
+
+    <section>
       <h3>Vue Chat</h3>
       <p>
         Uses <code>zodern:relay</code> to load and send messages.
@@ -40,7 +43,7 @@
         <input class="w-full" type="text" placeholder="Type your message here">
         <button>Send</button>
       </form>
-    </div>
+    </section>
   </div>
 </template>
 

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -37,7 +37,10 @@
         Uses <code>zodern:relay</code> to load and send messages.
       </p>
       <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64">
-        <div v-for="message in chat.data"></div>
+        <div v-for="message in chat.data">
+          <div>{{ message.content }}</div>
+          <div class="text-sm text-gray-500">{{ message.createdAt }}</div>
+        </div>
       </div>
       <form class="flex gap-2">
         <input class="w-full" type="text" placeholder="Type your message here">

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -42,9 +42,9 @@
           <div class="text-sm text-gray-500">{{ message.createdAt }}</div>
         </div>
       </div>
-      <form class="flex gap-2">
-        <input class="w-full" type="text" placeholder="Type your message here">
-        <button>Send</button>
+      <form class="flex gap-2" @submit.prevent="chat.send()">
+        <input class="w-full" type="text" v-model="chat.form.content" placeholder="Type your message here">
+        <button type="submit">Send</button>
       </form>
     </section>
   </div>

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -37,7 +37,7 @@
         Uses <code>zodern:relay</code> to load and send messages.
       </p>
       <div class="my-7 p-6 rounded-lg bg-gray-100 min-h-64">
-
+        <div v-for="message in chat.data"></div>
       </div>
       <form class="flex gap-2">
         <input class="w-full" type="text" placeholder="Type your message here">
@@ -49,6 +49,7 @@
 
 <script lang="ts" setup>
 import { reactive, ref } from 'vue';
+import type { ChatDocument } from '../api/chat/collection';
 import LinksCollection, { LinkDocument } from '../api/links/links.collection';
 import { Tracker } from 'meteor/tracker';
 import { Meteor } from 'meteor/meteor';
@@ -62,6 +63,17 @@ const links = reactive({
     },
     async create() {
         await Meteor.callAsync('links.create', links.form);
+    },
+});
+
+const chat = reactive({
+    data: [] as ChatDocument[],
+    ready: false,
+    form: {
+        message: '',
+    },
+    async send() {
+        await Meteor.callAsync('chat.send', chat.form);
     },
 });
 

--- a/examples/meteor-v3-vue/imports/ui/App.vue
+++ b/examples/meteor-v3-vue/imports/ui/App.vue
@@ -52,8 +52,9 @@
 
 <script lang="ts" setup>
 import { reactive, ref } from 'vue';
-import type { ChatDocument } from '../api/chat/collection';
+import { ChatCollection, type ChatDocument } from '../api/chat/collection';
 import { sendMessage } from '../api/chat/methods';
+import { subscribeToChat } from '../api/chat/publications';
 import LinksCollection, { LinkDocument } from '../api/links/links.collection';
 import { Tracker } from 'meteor/tracker';
 import { Meteor } from 'meteor/meteor';
@@ -82,8 +83,14 @@ const chat = reactive({
 });
 
 Tracker.autorun(() => {
-    const subscription = Meteor.subscribe('links');
-    links.ready = subscription.ready();
+    const linksSubscription = Meteor.subscribe('links');
+    links.ready = linksSubscription.ready();
     links.data = LinksCollection.find({}).fetch();
 });
+
+Tracker.autorun(() => {
+    const subscription = subscribeToChat();
+    chat.ready = subscription.ready();
+    chat.data = ChatCollection.find({}).fetch();
+})
 </script>

--- a/examples/meteor-v3-vue/imports/ui/GlobalState.ts
+++ b/examples/meteor-v3-vue/imports/ui/GlobalState.ts
@@ -1,0 +1,9 @@
+import { reactive } from 'vue';
+
+export const GlobalState = reactive({
+    currentTime: Date.now(),
+});
+
+setInterval(() => {
+    GlobalState.currentTime = Date.now();
+}, 1250);

--- a/examples/meteor-v3-vue/imports/ui/GlobalState.ts
+++ b/examples/meteor-v3-vue/imports/ui/GlobalState.ts
@@ -1,9 +1,22 @@
 import { reactive } from 'vue';
+import { generateUsername } from '../api/relay/methods/chat';
 
 export const GlobalState = reactive({
     currentTime: Date.now(),
 });
 
-setInterval(() => {
-    GlobalState.currentTime = Date.now();
-}, 1250);
+export const CurrentUser = reactive({
+    name: 'Unknown user',
+});
+
+Meteor.startup(async () => {
+    if (!Meteor.isClient) {
+        return;
+    }
+    
+    CurrentUser.name = await generateUsername();
+    setInterval(() => {
+        GlobalState.currentTime = Date.now();
+    }, 1250);
+
+})

--- a/examples/meteor-v3-vue/imports/ui/composition/Helpers.ts
+++ b/examples/meteor-v3-vue/imports/ui/composition/Helpers.ts
@@ -1,20 +1,9 @@
-import { differenceInMinutes, differenceInSeconds, formatDistance, formatDuration } from 'date-fns';
+import { formatDistance } from 'date-fns';
+import type { FormatDistanceOptions } from 'date-fns/formatDistance';
 import { GlobalState } from '../GlobalState';
 
-export function formatRelativeTime(date: Date, { suffix = true } = {}): string {
-    const minutes = differenceInMinutes(date, GlobalState.currentTime);
-    
-    if (minutes < 1) {
-        return 'just now';
-    }
-    
-    const distance = formatDuration({
-        minutes,
-    });
-    
-    if (!suffix) {
-        return distance;
-    }
-    
-    return `${distance} ago`;
+export function formatRelativeTime(date: Date, options: FormatDistanceOptions = {}): string {
+    return formatDistance(date, GlobalState.currentTime, Object.assign({
+        addSuffix: true,
+    }, options));
 }

--- a/examples/meteor-v3-vue/imports/ui/composition/Helpers.ts
+++ b/examples/meteor-v3-vue/imports/ui/composition/Helpers.ts
@@ -1,7 +1,7 @@
 import { differenceInMinutes, differenceInSeconds, formatDistance, formatDuration } from 'date-fns';
 import { GlobalState } from '../GlobalState';
 
-export function formatRelativeTime(date: Date, { suffix = true }): string {
+export function formatRelativeTime(date: Date, { suffix = true } = {}): string {
     const minutes = differenceInMinutes(date, GlobalState.currentTime);
     
     if (minutes < 1) {

--- a/examples/meteor-v3-vue/imports/ui/composition/Helpers.ts
+++ b/examples/meteor-v3-vue/imports/ui/composition/Helpers.ts
@@ -1,0 +1,20 @@
+import { differenceInMinutes, differenceInSeconds, formatDistance, formatDuration } from 'date-fns';
+import { GlobalState } from '../GlobalState';
+
+export function formatRelativeTime(date: Date, { suffix = true }): string {
+    const minutes = differenceInMinutes(date, GlobalState.currentTime);
+    
+    if (minutes < 1) {
+        return 'just now';
+    }
+    
+    const distance = formatDuration({
+        minutes,
+    });
+    
+    if (!suffix) {
+        return distance;
+    }
+    
+    return `${distance} ago`;
+}

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "vue-meteor-v3",
       "dependencies": {
+        "@babel/preset-typescript": "^7.24.7",
         "@babel/runtime": "^7.23.5",
         "@meteor-vite/plugin-zodern-relay": "^1.0.2",
         "@zodern/babel-plugin-meteor-relay": "^1.1.4",
@@ -835,6 +836,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
@@ -851,11 +863,42 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+      "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.24.7",
+        "@babel/helper-member-expression-to-functions": "^7.24.8",
+        "@babel/helper-optimise-call-expression": "^7.24.7",
+        "@babel/helper-replace-supers": "^7.25.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+        "@babel/traverse": "^7.25.4",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+      "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
+      "dependencies": {
+        "@babel/traverse": "^7.24.8",
+        "@babel/types": "^7.24.8"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
       "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
-      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -868,7 +911,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
       "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.24.7",
         "@babel/helper-simple-access": "^7.24.7",
@@ -882,11 +924,57 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+      "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+      "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.24.8",
+        "@babel/helper-optimise-call-expression": "^7.24.7",
+        "@babel/traverse": "^7.25.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
       "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
-      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+      "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -915,7 +1003,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
       "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -959,6 +1046,86 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.8"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
+      "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.24.8",
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-simple-access": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
+      "integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.24.7",
+        "@babel/helper-create-class-features-plugin": "^7.25.0",
+        "@babel/helper-plugin-utils": "^7.24.8",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+        "@babel/plugin-syntax-typescript": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
+      "integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-validator-option": "^7.24.7",
+        "@babel/plugin-syntax-jsx": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3896,7 +4063,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -9,7 +9,8 @@
         "@babel/runtime": "^7.23.5",
         "meteor-node-stubs": "^1.2.7",
         "meteor-vite": "^1.10.3",
-        "valibot": "^0.26.0"
+        "valibot": "^0.26.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^4.6.2",
@@ -2204,6 +2205,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -7,6 +7,7 @@
       "name": "vue-meteor-v3",
       "dependencies": {
         "@babel/runtime": "^7.23.5",
+        "@meteor-vite/plugin-zodern-relay": "^1.0.2",
         "meteor-node-stubs": "^1.2.7",
         "meteor-vite": "^1.10.3",
         "valibot": "^0.26.0",
@@ -17,6 +18,19 @@
         "typescript": "^5.3.3",
         "vite": "^4.5.2",
         "vue": "^3.4.14"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -31,12 +45,51 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/generator": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+    "node_modules/@babel/compat-data": {
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+      "peer": true,
       "dependencies": {
-        "@babel/types": "^7.24.7",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.0",
+        "@babel/helper-compilation-targets": "^7.25.2",
+        "@babel/helper-module-transforms": "^7.25.2",
+        "@babel/helpers": "^7.25.0",
+        "@babel/parser": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.2",
+        "@babel/types": "^7.25.2",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
+      "dependencies": {
+        "@babel/types": "^7.25.6",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -45,45 +98,60 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
+      "peer": true,
       "dependencies": {
+        "@babel/compat-data": "^7.25.2",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
+      "peer": true,
       "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/traverse": "^7.25.2"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
       },
-      "engines": {
-        "node": ">=6.9.0"
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-split-export-declaration": {
+    "node_modules/@babel/helper-simple-access": {
       "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "peer": true,
       "dependencies": {
+        "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
       },
       "engines": {
@@ -91,9 +159,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -102,6 +170,28 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
       "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+      "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.6"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -121,9 +211,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "dependencies": {
+        "@babel/types": "^7.25.6"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -143,31 +236,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/parser": "^7.25.0",
+        "@babel/types": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-hoist-variables": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/generator": "^7.25.6",
+        "@babel/parser": "^7.25.6",
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.6",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -176,11 +266,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
@@ -561,6 +651,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@meteor-vite/plugin-zodern-relay": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@meteor-vite/plugin-zodern-relay/-/plugin-zodern-relay-1.0.2.tgz",
+      "integrity": "sha512-qxPK8DuCn1HdDmOQKIS/WcDz0T+5lDpl8LFeCdY7y1A2UgRtRo3gAz30FUNzp9c7gyvV9sWD6QZjJgOfsEMv+g==",
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "vite": ">=3.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.2.tgz",
@@ -685,6 +784,58 @@
         "node": ">=4"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001664",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
+      "integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -711,6 +862,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "peer": true
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -732,6 +889,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
+      "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==",
+      "peer": true
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -781,6 +944,15 @@
         "@esbuild/win32-x64": "0.18.20"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -806,6 +978,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/globals": {
@@ -838,6 +1019,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/magic-string": {
@@ -2010,6 +2212,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "peer": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2025,9 +2233,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "node_modules/postcss": {
       "version": "8.4.39",
@@ -2076,6 +2284,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -2114,6 +2331,36 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/valibot": {
@@ -2195,6 +2442,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "peer": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -18,9 +18,24 @@
       "devDependencies": {
         "@types/meteor": "^2.9.8",
         "@vitejs/plugin-vue": "^4.6.2",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.47",
+        "tailwindcss": "^3.4.13",
         "typescript": "^5.6.2",
         "vite": "^4.5.2",
         "vue": "^3.4.14"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1512,6 +1527,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -1572,6 +1604,51 @@
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -2379,6 +2456,18 @@
       "resolved": "https://registry.npmjs.org/@zodern/babel-plugin-meteor-relay/-/babel-plugin-meteor-relay-1.1.4.tgz",
       "integrity": "sha512-yoJqDNlCE9pNkAen8EY9vW1l6ZEAg/6gVfPu0qCARFMP5K742VscuUelajCnNqGjqcpgQevw+mIs4wf3J7sMyQ=="
     },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -2389,6 +2478,74 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2410,12 +2567,45 @@
         }
       ]
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.24.0",
@@ -2435,7 +2625,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -2485,6 +2674,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001664",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
@@ -2502,8 +2700,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -2516,6 +2713,42 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/color-convert": {
@@ -2531,11 +2764,46 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -2559,11 +2827,34 @@
         }
       }
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.29",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
-      "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==",
-      "peer": true
+      "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2617,7 +2908,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2635,6 +2925,34 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -2659,6 +2977,56 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastq": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2672,6 +3040,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2679,6 +3056,38 @@
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/globals": {
@@ -2695,6 +3104,18 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ieee754": {
@@ -2728,6 +3149,102 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.6",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-tokens": {
@@ -2764,6 +3281,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2788,6 +3320,15 @@
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/meteor-node-stubs": {
       "version": "1.2.9",
@@ -3928,6 +4469,43 @@
         "vite": ">=3.0.0 < 5.0.0"
       }
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mongodb": {
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
@@ -3961,6 +4539,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -3981,8 +4570,43 @@
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "peer": true
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -3998,15 +4622,88 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
       "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/postcss": {
-      "version": "8.4.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4023,12 +4720,139 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "dev": true,
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4039,10 +4863,78 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rollup": {
       "version": "3.29.4",
@@ -4059,12 +4951,68 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/smart-buffer": {
@@ -4092,9 +5040,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4115,12 +5063,130 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -4133,12 +5199,94 @@
         "node": ">=4"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.13.tgz",
+      "integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.0",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tr46": {
@@ -4152,6 +5300,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "node_modules/tslib": {
       "version": "2.7.0",
@@ -4197,7 +5351,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.0"
@@ -4208,6 +5361,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -4325,11 +5484,159 @@
         "node": ">=12"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "peer": true
+    },
+    "node_modules/yaml": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@babel/runtime": "^7.23.5",
         "@meteor-vite/plugin-zodern-relay": "^1.0.2",
+        "@zodern/babel-plugin-meteor-relay": "^1.1.4",
         "meteor-node-stubs": "^1.2.7",
         "meteor-vite": "^1.10.3",
         "valibot": "^0.26.0",
@@ -772,6 +773,11 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.31.tgz",
       "integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA==",
       "dev": true
+    },
+    "node_modules/@zodern/babel-plugin-meteor-relay": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@zodern/babel-plugin-meteor-relay/-/babel-plugin-meteor-relay-1.1.4.tgz",
+      "integrity": "sha512-yoJqDNlCE9pNkAen8EY9vW1l6ZEAg/6gVfPu0qCARFMP5K742VscuUelajCnNqGjqcpgQevw+mIs4wf3J7sMyQ=="
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -15,6 +15,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/meteor": "^2.9.8",
         "@vitejs/plugin-vue": "^4.6.2",
         "typescript": "^5.3.3",
         "vite": "^4.5.2",
@@ -32,6 +33,741 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.658.1.tgz",
+      "integrity": "sha512-MCYLKmNy0FlNT9TvXfOxj0jh+ZQq+G9qEy/VZqu3JsQSgiFvFRdzgzcbQ9gQx7fZrDC/TPdABOTh483zI4cu9g==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.658.1",
+        "@aws-sdk/client-sts": "3.658.1",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.658.1.tgz",
+      "integrity": "sha512-lOuaBtqPTYGn6xpXlQF4LsNDsQ8Ij2kOdnk+i69Kp6yS76TYvtUuukyLL5kx8zE1c8WbYtxj9y8VNw9/6uKl7Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.658.1.tgz",
+      "integrity": "sha512-RGcZAI3qEA05JszPKwa0cAyp8rnS1nUvs0Sqw4hqLNQ1kD7b7V6CPjRXe7EFQqCOMvM4kGqx0+cEEVTOmBsFLw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.658.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.658.1.tgz",
+      "integrity": "sha512-yw9hc5blTnbT1V6mR7Cx9HGc9KQpcLQ1QXj8rntiJi6tIYu3aFNVEyy81JHL7NsuBSeQulJTvHO3y6r3O0sfRg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.658.1",
+        "@aws-sdk/core": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
+        "@aws-sdk/middleware-host-header": "3.654.0",
+        "@aws-sdk/middleware-logger": "3.654.0",
+        "@aws-sdk/middleware-recursion-detection": "3.654.0",
+        "@aws-sdk/middleware-user-agent": "3.654.0",
+        "@aws-sdk/region-config-resolver": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@aws-sdk/util-user-agent-browser": "3.654.0",
+        "@aws-sdk/util-user-agent-node": "3.654.0",
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/core": "^2.4.6",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/hash-node": "^3.0.6",
+        "@smithy/invalid-dependency": "^3.0.6",
+        "@smithy/middleware-content-length": "^3.0.8",
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.21",
+        "@smithy/util-defaults-mode-node": "^3.0.21",
+        "@smithy/util-endpoints": "^2.1.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.658.1.tgz",
+      "integrity": "sha512-vJVMoMcSKXK2gBRSu9Ywwv6wQ7tXH8VL1fqB1uVxgCqBZ3IHfqNn4zvpMPWrwgO2/3wv7XFyikGQ5ypPTCw4jA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^2.4.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/signature-v4": "^4.1.4",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.658.1.tgz",
+      "integrity": "sha512-JY4rZ4e2emL7PNHCU7F/BQV8PpQGEBZLkEoPD55RO4CitaIhlVZRpUCGLih+0Hw4MOnTUqJdfQBM+qZk6G+Now==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.658.1",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.654.0.tgz",
+      "integrity": "sha512-kogsx3Ql81JouHS7DkheCDU9MYAvK0AokxjcshDveGmf7BbgbWCA8Fnb9wjQyNDaOXNvkZu8Z8rgkX91z324/w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.658.1.tgz",
+      "integrity": "sha512-4ubkJjEVCZflxkZnV1JDQv8P2pburxk1LrEp55telfJRzXrnowzBKwuV2ED0QMNC448g2B3VCaffS+Ct7c4IWQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.658.1.tgz",
+      "integrity": "sha512-2uwOamQg5ppwfegwen1ddPu5HM3/IBSnaGlaKLFhltkdtZ0jiqTZWUtX2V+4Q+buLnT0hQvLS/frQ+7QUam+0Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.658.1",
+        "@aws-sdk/credential-provider-process": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.658.1",
+        "@aws-sdk/credential-provider-web-identity": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.658.1"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.658.1.tgz",
+      "integrity": "sha512-XwxW6N+uPXPYAuyq+GfOEdfL/MZGAlCSfB5gEWtLBFmFbikhmEuqfWtI6CD60OwudCUOh6argd21BsJf8o1SJA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.658.1",
+        "@aws-sdk/credential-provider-ini": "3.658.1",
+        "@aws-sdk/credential-provider-process": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.658.1",
+        "@aws-sdk/credential-provider-web-identity": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.654.0.tgz",
+      "integrity": "sha512-PmQoo8sZ9Q2Ow8OMzK++Z9lI7MsRUG7sNq3E72DVA215dhtTICTDQwGlXH2AAmIp7n+G9LLRds+4wo2ehG4mkg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.658.1.tgz",
+      "integrity": "sha512-YOagVEsZEk9DmgJEBg+4MBXrPcw/tYas0VQ5OVBqC5XHNbi2OBGJqgmjVPesuu393E7W0VQxtJFDS00O1ewQgA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.658.1",
+        "@aws-sdk/token-providers": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.654.0.tgz",
+      "integrity": "sha512-6a2g9gMtZToqSu+CusjNK5zvbLJahQ9di7buO3iXgbizXpLXU1rnawCpWxwslMpT5fLgMSKDnKDrr6wdEk7jSw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.658.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.658.1.tgz",
+      "integrity": "sha512-lfXA6kZS6GHyi/67EbfrKdLoqHR6j7G35eFwaqxyNkfMhNBpAF0eZK3SYiwnzdR9+Wb/enTFawYiFbG5R+dQzA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.658.1",
+        "@aws-sdk/client-sso": "3.658.1",
+        "@aws-sdk/client-sts": "3.658.1",
+        "@aws-sdk/credential-provider-cognito-identity": "3.658.1",
+        "@aws-sdk/credential-provider-env": "3.654.0",
+        "@aws-sdk/credential-provider-http": "3.658.1",
+        "@aws-sdk/credential-provider-ini": "3.658.1",
+        "@aws-sdk/credential-provider-node": "3.658.1",
+        "@aws-sdk/credential-provider-process": "3.654.0",
+        "@aws-sdk/credential-provider-sso": "3.658.1",
+        "@aws-sdk/credential-provider-web-identity": "3.654.0",
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.654.0.tgz",
+      "integrity": "sha512-rxGgVHWKp8U2ubMv+t+vlIk7QYUaRCHaVpmUlJv0Wv6Q0KeO9a42T9FxHphjOTlCGQOLcjCreL9CF8Qhtb4mdQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.654.0.tgz",
+      "integrity": "sha512-OQYb+nWlmASyXfRb989pwkJ9EVUMP1CrKn2eyTk3usl20JZmKo2Vjis6I0tLUkMSxMhnBJJlQKyWkRpD/u1FVg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.654.0.tgz",
+      "integrity": "sha512-gKSomgltKVmsT8sC6W7CrADZ4GHwX9epk3GcH6QhebVO3LA9LRbkL3TwOPUXakxxOLLUTYdOZLIOtFf7iH00lg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.654.0.tgz",
+      "integrity": "sha512-liCcqPAyRsr53cy2tYu4qeH4MMN0eh9g6k56XzI5xd4SghXH5YWh4qOYAlQ8T66ZV4nPMtD8GLtLXGzsH8moFg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@aws-sdk/util-endpoints": "3.654.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.654.0.tgz",
+      "integrity": "sha512-ydGOrXJxj3x0sJhsXyTmvJVLAE0xxuTWFJihTl67RtaO7VRNtd82I3P3bwoMMaDn5WpmV5mPo8fEUDRlBm3fPg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.654.0.tgz",
+      "integrity": "sha512-D8GeJYmvbfWkQDtTB4owmIobSMexZel0fOoetwvgCQ/7L8VPph3Q2bn1TRRIXvH7wdt6DcDxA3tKMHPBkT3GlA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.654.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.654.0.tgz",
+      "integrity": "sha512-VWvbED3SV+10QJIcmU/PKjsKilsTV16d1I7/on4bvD/jo1qGeMXqLDBSen3ks/tuvXZF/mFc7ZW/W2DiLVtO7A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.654.0.tgz",
+      "integrity": "sha512-i902fcBknHs0Irgdpi62+QMvzxE+bczvILXigYrlHL4+PiEnlMVpni5L5W1qCkNZXf8AaMrSBuR1NZAGp6UOUw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-endpoints": "^2.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.654.0.tgz",
+      "integrity": "sha512-ykYAJqvnxLt7wfrqya28wuH3/7NdrwzfiFd7NqEVQf7dXVxL5RPEpD7DxjcyQo3DsHvvdUvGZVaQhozycn1pzA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/types": "^3.4.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.654.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.654.0.tgz",
+      "integrity": "sha512-a0ojjdBN6pqv6gB4H/QPPSfhs7mFtlVwnmKCM/QrTaFzN0U810PJ1BST3lBx5sa23I5jWHGaoFY+5q65C3clLQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.654.0",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -661,6 +1397,703 @@
         "vite": ">=3.0.0"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.4.tgz",
+      "integrity": "sha512-VupaALAQlXViW3/enTf/f5l5JZYSAxoJL7f0nanhNNKnww6DGCg1oYIuNP78KDugnkwthBO6iEcym16HhWV8RQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.8.tgz",
+      "integrity": "sha512-Tv1obAC18XOd2OnDAjSWmmthzx6Pdeh63FbLin8MlPiuJ2ATpKkq0NcNOJFr0dO+JmZXnwu8FQxKJ3TKJ3Hulw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.6.tgz",
+      "integrity": "sha512-6lQQp99hnyuNNIzeTYSzCUXJHwvvFLY7hfdFGSJM95tjRDJGfzWYFRBXPaM9766LiiTsQ561KErtbufzUFSYUg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-retry": "^3.0.21",
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.3.tgz",
+      "integrity": "sha512-VoxMzSzdvkkjMJNE38yQgx4CfnmT+Z+5EUXkg4x7yag93eQkVQgZvN3XBSHC/ylfBbLbAtdu7flTCChX9I+mVg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.8.tgz",
+      "integrity": "sha512-Lqe0B8F5RM7zkw//6avq1SJ8AfaRd3ubFUS1eVp5WszV7p6Ne5hQ4dSuMHDpNRPhgTvj4va9Kd/pcVigHEHRow==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.6.tgz",
+      "integrity": "sha512-c/FHEdKK/7DU2z6ZE91L36ahyXWayR3B+FzELjnYq7wH5YqIseM24V+pWCS9kFn1Ln8OFGTf+pyYPiHZuX0s/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.6.tgz",
+      "integrity": "sha512-czM7Ioq3s8pIXht7oD+vmgy4Wfb4XavU/k/irO8NdXFFOx7YAlsCCcKOh/lJD1mJSYQqiR7NmpZ9JviryD/7AQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.8.tgz",
+      "integrity": "sha512-VuyszlSO49WKh3H9/kIO2kf07VUwGV80QRiaDxUfP8P8UKlokz381ETJvwLhwuypBYhLymCYyNhB3fLAGBX2og==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.3.tgz",
+      "integrity": "sha512-KeM/OrK8MVFUsoJsmCN0MZMVPjKKLudn13xpgwIMpGTYpA8QZB2Xq5tJ+RE6iu3A6NhOI4VajDTwBsm8pwwrhg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.6",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "@smithy/url-parser": "^3.0.6",
+        "@smithy/util-middleware": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.21.tgz",
+      "integrity": "sha512-/h0fElV95LekVVEJuSw+aI11S1Y3zIUwBc6h9ZbUv43Gl2weXsbQwjLoet6j/Qtb0phfrSxS6pNg6FqgJOWZkA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-retry": "^3.0.6",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.6.tgz",
+      "integrity": "sha512-KKTUSl1MzOM0MAjGbudeaVNtIDo+PpekTBkCNwvfZlKndodrnvRo+00USatiyLOc0ujjO9UydMRu3O9dYML7ag==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.6.tgz",
+      "integrity": "sha512-2c0eSYhTQ8xQqHMcRxLMpadFbTXg6Zla5l0mwNftFCZMQmuhI7EbAJMx6R5eqfuV3YbJ3QGyS3d5uSmrHV8Khg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.7.tgz",
+      "integrity": "sha512-g3mfnC3Oo8pOI0dYuPXLtdW1WGVb3bR2tkV21GNkm0ZvQjLTtamXAwCWt/FCb0HGvKt3gHHmF1XerG0ICfalOg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/shared-ini-file-loader": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.3.tgz",
+      "integrity": "sha512-/gcm5DJ3k1b1zEInzBGAZC8ntJ+jwrz1NcSIu+9dSXd1FfG0G6QgkDI40tt8/WYUbHtLyo8fEqtm2v29koWo/w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/querystring-builder": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.6.tgz",
+      "integrity": "sha512-NK3y/T7Q/Bw+Z8vsVs9MYIQ5v7gOX7clyrXcwhhIBQhbPgRl6JDrZbusO9qWDhcEus75Tg+VCxtIRfo3H76fpw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.3.tgz",
+      "integrity": "sha512-GcbMmOYpH9iRqtC05RbRnc/0FssxSTHlmaNhYBTgSgNCYpdR3Kt88u5GAZTBmouzv+Zlj/VRv92J9ruuDeJuEw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.6.tgz",
+      "integrity": "sha512-sQe08RunoObe+Usujn9+R2zrLuQERi3CWvRO3BvnoWSYUaIrLKuAIeY7cMeDax6xGyfIP3x/yFWbEKSXvOnvVg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.6.tgz",
+      "integrity": "sha512-UJKw4LlEkytzz2Wq+uIdHf6qOtFfee/o7ruH0jF5I6UAuU+19r9QV7nU3P/uI0l6+oElRHmG/5cBBcGJrD7Ozg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.6.tgz",
+      "integrity": "sha512-53SpchU3+DUZrN7J6sBx9tBiCVGzsib2e4sc512Q7K9fpC5zkJKs6Z9s+qbMxSYrkEkle6hnMtrts7XNkMJJMg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.7.tgz",
+      "integrity": "sha512-IA4K2qTJYXkF5OfVN4vsY1hfnUZjaslEE8Fsr/gGFza4TAC2A9NfnZuSY2srQIbt9bwtjHiAayrRVgKse4Q7fA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.4.tgz",
+      "integrity": "sha512-72MiK7xYukNsnLJI9NqvUHqTu0ziEsfMsYNlWpiJfuGQnCTFKpckThlEatirvcA/LmT1h7rRO+pJD06PYsPu9Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.6",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.5.tgz",
+      "integrity": "sha512-7IZi8J3Dr9n3tX+lcpmJ/5tCYIqoXdblFBaPuv0SEKZFRpCxE+TqIWL6I3t7jLlk9TWu3JSvEZAhtjB9yvB+zA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.1.3",
+        "@smithy/middleware-stack": "^3.0.6",
+        "@smithy/protocol-http": "^4.1.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-stream": "^3.1.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
+      "integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.6.tgz",
+      "integrity": "sha512-47Op/NU8Opt49KyGpHtVdnmmJMsp2hEwBdyjuFB9M2V5QVOwA7pBhhxKN5z6ztKGrMw76gd8MlbPuzzvaAncuQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.21.tgz",
+      "integrity": "sha512-M/FhTBk4c/SsB91dD/M4gMGfJO7z/qJaM9+XQQIqBOf4qzZYMExnP7R4VdGwxxH8IKMGW+8F0I4rNtVRrcfPoA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.21.tgz",
+      "integrity": "sha512-NiLinPvF86U3S2Pdx/ycqd4bnY5dmFSPNL5KYRwbNjqQFS09M5Wzqk8BNk61/47xCYz1X/6KeiSk9qgYPTtuDw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.8",
+        "@smithy/credential-provider-imds": "^3.2.3",
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/property-provider": "^3.1.6",
+        "@smithy/smithy-client": "^3.3.5",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.2.tgz",
+      "integrity": "sha512-FEISzffb4H8DLzGq1g4MuDpcv6CIG15fXoQzDH9SjpRJv6h7J++1STFWWinilG0tQh9H1v2UKWG19Jjr2B16zQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.7",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.6.tgz",
+      "integrity": "sha512-BxbX4aBhI1O9p87/xM+zWy0GzT3CEVcXFPBRDoHAM+pV0eSW156pR+PSYEz0DQHDMYDsYAflC2bQNz2uaDBUZQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.6.tgz",
+      "integrity": "sha512-BRZiuF7IwDntAbevqMco67an0Sr9oLQJqqRCsSPZZHYRnehS0LHDAkJk/pSmI7Z8c/1Vet294H7fY2fWUgB+Rg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.6",
+        "@smithy/types": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.8.tgz",
+      "integrity": "sha512-hoKOqSmb8FD3WLObuB5hwbM7bNIWgcnvkThokTvVq7J5PKjlLUK5qQQcB9zWLHIoSaIlf3VIv2OxZY2wtQjcRQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.2.8",
+        "@smithy/node-http-handler": "^3.2.3",
+        "@smithy/types": "^3.4.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/jquery": {
+      "version": "3.5.31",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.31.tgz",
+      "integrity": "sha512-rf/iB+cPJ/YZfMwr+FVuQbm7IaWC4y3FVYfVDxRGqmUCFjjPII0HWaP0vTPJGp6m4o13AXySCcMbWfrWtBFAKw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/meteor": {
+      "version": "2.9.8",
+      "resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-2.9.8.tgz",
+      "integrity": "sha512-p96s1lMqtwt0hz50yokQJA+V9BQzNMLJfahwlbbfXKwbI/OMNCKhRfnxiiNROXAF080zctJlEcpjmv0YG7ztkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/jquery": "*",
+        "@types/node": "*",
+        "@types/nodemailer": "*",
+        "@types/react": "*",
+        "@types/underscore": "*",
+        "mongodb": "^4.3.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "devOptional": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.16",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.16.tgz",
+      "integrity": "sha512-uz6hN6Pp0upXMcilM61CoKyjT7sskBoOWpptkjjJp8jIMlTdc3xG01U7proKkXzruMS4hS0zqtHNkNPFB20rKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.13",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
+      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.10.tgz",
+      "integrity": "sha512-02sAAlBnP39JgXwkAq3PeU9DVaaGpZyF3MGcC0MKgQVkZor5IiiDAipVaxQHtDJAmO4GIy/rVBy/LzVj76Cyqg==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
+      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
+      "dev": true
+    },
+    "node_modules/@types/underscore": {
+      "version": "1.11.15",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.15.tgz",
+      "integrity": "sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==",
+      "dev": true
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.2.tgz",
@@ -790,6 +2223,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/browserslist": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
@@ -820,6 +2280,42 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bson": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/caniuse-lite": {
@@ -973,6 +2469,29 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1011,10 +2530,49 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -1056,6 +2614,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/meteor-node-stubs": {
       "version": "1.2.9",
@@ -2196,6 +3761,34 @@
         "vite": ">=3.0.0 < 5.0.0"
       }
     },
+    "node_modules/mongodb": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+      "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
+      "dev": true,
+      "dependencies": {
+        "bson": "^4.7.2",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "@mongodb-js/saslprep": "^1.1.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2270,6 +3863,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -2299,6 +3901,30 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "dev": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -2306,6 +3932,29 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -2326,6 +3975,25 @@
         "node": ">=4"
       }
     },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
@@ -2338,6 +4006,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "devOptional": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
@@ -2367,6 +4041,20 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/valibot": {
@@ -2447,6 +4135,28 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yallist": {

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/meteor": "^2.9.8",
         "@vitejs/plugin-vue": "^4.6.2",
-        "typescript": "^5.3.3",
+        "typescript": "^5.6.2",
         "vite": "^4.5.2",
         "vue": "^3.4.14"
       }
@@ -3995,9 +3995,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -16,6 +16,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.15",
         "@types/meteor": "^2.9.8",
         "@vitejs/plugin-vue": "^4.6.2",
         "autoprefixer": "^10.4.20",
@@ -2243,6 +2244,34 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.15.tgz",
+      "integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3294,6 +3323,24 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "node_modules/lru-cache": {

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",
         "@babel/runtime": "^7.23.5",
+        "@faker-js/faker": "^9.0.3",
         "@meteor-vite/plugin-zodern-relay": "^1.0.2",
         "@zodern/babel-plugin-meteor-relay": "^1.1.4",
         "date-fns": "^4.1.0",
@@ -1527,6 +1528,21 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.0.3.tgz",
+      "integrity": "sha512-lWrrK4QNlFSU+13PL9jMbMKLJYXDFu3tQfayBsMXX7KL/GiQeqfB1CzHkqD5UHBUtPAuPo6XwGbMFNdVMZObRA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/examples/meteor-v3-vue/package-lock.json
+++ b/examples/meteor-v3-vue/package-lock.json
@@ -10,6 +10,7 @@
         "@babel/runtime": "^7.23.5",
         "@meteor-vite/plugin-zodern-relay": "^1.0.2",
         "@zodern/babel-plugin-meteor-relay": "^1.1.4",
+        "date-fns": "^4.1.0",
         "meteor-node-stubs": "^1.2.7",
         "meteor-vite": "^1.10.3",
         "valibot": "^0.26.0",
@@ -2839,6 +2840,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.5",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -12,6 +12,7 @@
     "@babel/runtime": "^7.23.5",
     "@meteor-vite/plugin-zodern-relay": "^1.0.2",
     "@zodern/babel-plugin-meteor-relay": "^1.1.4",
+    "date-fns": "^4.1.0",
     "meteor-node-stubs": "^1.2.7",
     "meteor-vite": "^1.10.3",
     "valibot": "^0.26.0",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -8,6 +8,7 @@
     "visualize": "meteor --production --extra-packages bundle-visualizer"
   },
   "dependencies": {
+    "@babel/preset-typescript": "^7.24.7",
     "@babel/runtime": "^7.23.5",
     "@meteor-vite/plugin-zodern-relay": "^1.0.2",
     "@zodern/babel-plugin-meteor-relay": "^1.1.4",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -24,6 +24,7 @@
     "testModule": "tests/main.js"
   },
   "devDependencies": {
+    "@types/meteor": "^2.9.8",
     "@vitejs/plugin-vue": "^4.6.2",
     "typescript": "^5.3.3",
     "vite": "^4.5.2",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.5",
     "@meteor-vite/plugin-zodern-relay": "^1.0.2",
+    "@zodern/babel-plugin-meteor-relay": "^1.1.4",
     "meteor-node-stubs": "^1.2.7",
     "meteor-vite": "^1.10.3",
     "valibot": "^0.26.0",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -27,6 +27,9 @@
   "devDependencies": {
     "@types/meteor": "^2.9.8",
     "@vitejs/plugin-vue": "^4.6.2",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
     "vite": "^4.5.2",
     "vue": "^3.4.14"

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
+    "@meteor-vite/plugin-zodern-relay": "^1.0.2",
     "meteor-node-stubs": "^1.2.7",
     "meteor-vite": "^1.10.3",
     "valibot": "^0.26.0",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -11,7 +11,8 @@
     "@babel/runtime": "^7.23.5",
     "meteor-node-stubs": "^1.2.7",
     "meteor-vite": "^1.10.3",
-    "valibot": "^0.26.0"
+    "valibot": "^0.26.0",
+    "zod": "^3.23.8"
   },
   "meteor": {
     "mainModule": {

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.24.7",
     "@babel/runtime": "^7.23.5",
+    "@faker-js/faker": "^9.0.3",
     "@meteor-vite/plugin-zodern-relay": "^1.0.2",
     "@zodern/babel-plugin-meteor-relay": "^1.1.4",
     "date-fns": "^4.1.0",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -25,6 +25,7 @@
     "testModule": "tests/main.js"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.15",
     "@types/meteor": "^2.9.8",
     "@vitejs/plugin-vue": "^4.6.2",
     "autoprefixer": "^10.4.20",

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/meteor": "^2.9.8",
     "@vitejs/plugin-vue": "^4.6.2",
-    "typescript": "^5.3.3",
+    "typescript": "^5.6.2",
     "vite": "^4.5.2",
     "vue": "^3.4.14"
   }

--- a/examples/meteor-v3-vue/packages/zodern-relay/package.js
+++ b/examples/meteor-v3-vue/packages/zodern-relay/package.js
@@ -11,7 +11,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.versionsFrom('2.2');
+  api.versionsFrom(['2.2', '3.0']);
   api.use('typescript');
   api.use('ddp-rate-limiter');
   api.use('zodern:types@1.0.9');

--- a/examples/meteor-v3-vue/packages/zodern-relay/server-main.ts
+++ b/examples/meteor-v3-vue/packages/zodern-relay/server-main.ts
@@ -66,7 +66,7 @@ export function createMethod<S extends z.ZodUndefined | z.ZodTypeAny, T>(config:
   let name = config.name;
 
   Meteor.methods({
-    [name](data) {
+    async [name](data) {
       if (pipeline.length === 0) {
         throw new Error(`Pipeline or run function for ${name} never configured`);
       }
@@ -108,7 +108,7 @@ export function createMethod<S extends z.ZodUndefined | z.ZodTypeAny, T>(config:
       }
 
       try {
-        let result = (Promise as any).await(run());
+        let result = await run();
 
         onResult.forEach(callback => {
           callback(result);
@@ -180,7 +180,7 @@ export function createPublication<S extends z.ZodTypeAny, T>(
 
   let name = config.name;
 
-  Meteor.publish(name, function (data: z.input<S>) {
+  Meteor.publish(name, async function (data: z.input<S>) {
     if (pipeline.length === 0) {
       throw new Error(`Pipeline or run function never configured for ${name} publication`);
     }
@@ -331,7 +331,7 @@ export function createPublication<S extends z.ZodTypeAny, T>(
     }
 
     try {
-      const result = (Promise as any).await(run(0, parsed));
+      const result = await run(0, parsed);
 
       onResult.forEach(cb => {
         cb(result.output);

--- a/examples/meteor-v3-vue/postcss.config.js
+++ b/examples/meteor-v3-vue/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/examples/meteor-v3-vue/server/main.ts
+++ b/examples/meteor-v3-vue/server/main.ts
@@ -3,8 +3,8 @@ import { onPageLoad } from "meteor/server-render";
 import LinksCollection from '../imports/api/links/links.collection';
 import '../imports/api/links/links.methods';
 import '../imports/api/links/server/links.publications';
-import '../imports/api/chat/publications';
-import '../imports/api/chat/methods';
+import '../imports/api/relay/publications/chat';
+import '../imports/api/relay/methods/chat';
 
 Meteor.startup(async () => {
   // Code to run on server startup.

--- a/examples/meteor-v3-vue/server/main.ts
+++ b/examples/meteor-v3-vue/server/main.ts
@@ -3,6 +3,8 @@ import { onPageLoad } from "meteor/server-render";
 import LinksCollection from '../imports/api/links/links.collection';
 import '../imports/api/links/links.methods';
 import '../imports/api/links/server/links.publications';
+import '../imports/api/chat/publications';
+import '../imports/api/chat/methods';
 
 Meteor.startup(async () => {
   // Code to run on server startup.

--- a/examples/meteor-v3-vue/tailwind.config.js
+++ b/examples/meteor-v3-vue/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+

--- a/examples/meteor-v3-vue/tailwind.config.js
+++ b/examples/meteor-v3-vue/tailwind.config.js
@@ -7,6 +7,8 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+      require('@tailwindcss/typography'),
+  ],
 }
 

--- a/examples/meteor-v3-vue/tailwind.config.js
+++ b/examples/meteor-v3-vue/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [],
+  content: [
+      "client/**/*.html",
+      "imports/**/*.{vue,ts,js}"
+  ],
   theme: {
     extend: {},
   },

--- a/examples/meteor-v3-vue/tsconfig.json
+++ b/examples/meteor-v3-vue/tsconfig.json
@@ -30,7 +30,7 @@
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
      "paths": {
-       "meteor/zodern:relay": ["./packages/zodern-relay/client-main.ts"]
+       "meteor/zodern:relay": ["./packages/zodern-relay/server-main.ts"]
      },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/examples/meteor-v3-vue/tsconfig.json
+++ b/examples/meteor-v3-vue/tsconfig.json
@@ -29,7 +29,9 @@
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+     "paths": {
+       "meteor/zodern:relay": ["./packages/zodern-relay/client-main.ts"]
+     },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */

--- a/examples/meteor-v3-vue/vite.config.ts
+++ b/examples/meteor-v3-vue/vite.config.ts
@@ -15,13 +15,13 @@ export default defineConfig({
                  * Path to directories where your zodern:relay methods live
                  * @default ['./imports/methods']
                  */
-                methods: ['./imports/methods'],
+                methods: ['./imports/api'],
                 
                 /**
                  * Path to the directories where your zodern:relay publications live.
                  * @default ['./imports/publications']
                  */
-                publications: ['./imports/publications'],
+                publications: ['./imports/api'],
             }
         }),
     ],

--- a/examples/meteor-v3-vue/vite.config.ts
+++ b/examples/meteor-v3-vue/vite.config.ts
@@ -15,13 +15,13 @@ export default defineConfig({
                  * Path to directories where your zodern:relay methods live
                  * @default ['./imports/methods']
                  */
-                methods: ['./imports/api'],
+                methods: ['./imports/api/relay/methods'],
                 
                 /**
                  * Path to the directories where your zodern:relay publications live.
                  * @default ['./imports/publications']
                  */
-                publications: ['./imports/api'],
+                publications: ['./imports/api/relay/publications'],
             }
         }),
     ],

--- a/examples/meteor-v3-vue/vite.config.ts
+++ b/examples/meteor-v3-vue/vite.config.ts
@@ -1,12 +1,28 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { meteor } from 'meteor-vite/plugin';
+import zodernRelay from '@meteor-vite/plugin-zodern-relay';
 
 export default defineConfig({
     plugins: [
         vue(),
         meteor({
             clientEntry: 'imports/entrypoint/vite-client.ts',
+        }),
+        zodernRelay({
+            directories: {
+                /**
+                 * Path to directories where your zodern:relay methods live
+                 * @default ['./imports/methods']
+                 */
+                methods: ['./imports/methods'],
+                
+                /**
+                 * Path to the directories where your zodern:relay publications live.
+                 * @default ['./imports/publications']
+                 */
+                publications: ['./imports/publications'],
+            }
         }),
     ],
     optimizeDeps: {

--- a/npm-packages/zodern-relay/package.json
+++ b/npm-packages/zodern-relay/package.json
@@ -22,7 +22,8 @@
     "lint": "tsc --noEmit",
     "test": "npm run lint",
     "build": "tsup",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "prepare": "npm run build || echo 'Warning: Failed to prepare package!' && exit 0"
   },
   "keywords": [
     "meteor-vite",

--- a/npm-packages/zodern-relay/src/Plugin.ts
+++ b/npm-packages/zodern-relay/src/Plugin.ts
@@ -36,10 +36,18 @@ export default async function zodernRelay(options?: Options): Promise<Plugin> {
         name: 'zodern-relay',
         async load(filename) {
             const relay = resolveRelay(filename || '');
+            
             if (!relay) {
                 return;
             }
+            
             const code = FS.readFileSync(filename, 'utf-8');
+            
+            // Prevent transforming files that don't use zodern:relay
+            if (!code.includes('meteor/zodern:relay')) {
+                return;
+            }
+            
             const transform = await transformAsync(code, {
                 configFile: false,
                 babelrc: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1201 @@
+{
+  "name": "relay",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.18.6"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@tsd/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
+      "dev": true
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+      "dev": true
+    },
+    "@types/jquery": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/meteor": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-2.7.1.tgz",
+      "integrity": "sha512-bLoDKKKVRbLIUCA1Fy41+vLjRi6M1iMr3bGvq0Hz/66SraYuiQ0Mit1ql2Y4Z/7Oo+9YXYUikTlmgwSTNPE6PA==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/jquery": "*",
+        "@types/react": "*",
+        "@types/underscore": "*",
+        "mongodb": "^4.3.1"
+      }
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.7.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
+      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "18.0.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
+      "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
+    },
+    "@types/underscore": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.4.tgz",
+      "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==",
+      "dev": true
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q==",
+      "dev": true
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "bson": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+      "integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "dev": true
+        }
+      }
+    },
+    "denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
+    },
+    "eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "eslint-rule-docs": {
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "dev": true
+    },
+    "irregular-plurals": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "optional": true
+    },
+    "meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        }
+      }
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
+    },
+    "mongodb": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
+      "integrity": "sha512-/NyiM3Ox9AwP5zrfT9TXjRKDJbXlLaUDQ9Rg//2lbg8D2A8GXV0VidYYnA/gfdK6uwbnL4FnAflH7FbGw3TS7w==",
+      "dev": true,
+      "requires": {
+        "bson": "^4.6.5",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.5.2",
+        "saslprep": "^1.0.3",
+        "socks": "^2.6.2"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+      "dev": true,
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^3.2.0"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
+    "socks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "dev": true,
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
+    },
+    "tsd": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.22.0.tgz",
+      "integrity": "sha512-NH+tfEDQ0Ze8gH7TorB6IxYybD+M68EYawe45YNVrbQcydNBfdQHP9IiD0QbnqmwNXrv+l9GAiULT68mo4q/xA==",
+      "dev": true,
+      "requires": {
+        "@tsd/typescript": "~4.7.4",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      }
+    },
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
+      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7266,7 +7266,7 @@
       }
     },
     "packages/vite-bundler": {
-      "version": "2.0.1"
+      "version": "2.0.2"
     }
   }
 }

--- a/package-types.json
+++ b/package-types.json
@@ -1,0 +1,3 @@
+{
+  "typesEntry": "./server-main.ts"
+}

--- a/package.js
+++ b/package.js
@@ -1,0 +1,38 @@
+Package.describe({
+  name: 'zodern:relay',
+  version: '1.1.1',
+  // Brief, one-line summary of the package.
+  summary: 'Type safe Meteor methods and publications',
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/zodern/meteor-relay.git',
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('2.2');
+  api.use('typescript');
+  api.use('ddp-rate-limiter');
+  api.use('zodern:types@1.0.9');
+  api.mainModule('server-main.ts', 'server');
+  api.mainModule('client-main.ts', 'client');
+});
+
+Package.onTest(function(api) {
+  api.use('ecmascript');
+  api.use('typescript');
+  api.use('tinytest');
+  api.use('mongo');
+  api.use('zodern:relay');
+  api.addFiles([
+    'tests/methods/index.js',
+    'tests/publications/index.js',
+  ], 'server');
+  api.addFiles([
+    'tests/method-tests.js',
+  ]);
+  api.addFiles([
+  'tests/publication-tests.js',
+  ], 'client');
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "relay",
+  "private": true,
+  "description": "",
+  "devDependencies": {
+    "@types/meteor": "^2.7.1",
+    "tsd": "^0.22.0",
+    "typescript": "^4.7.4",
+    "zod": "^3.18.0"
+  },
+  "scripts": {
+    "check-types": "npm install && tsc && tsd ./tests",
+    "postcheck-types": "npm prune --prod"
+  },
+  "license": "MIT"
+}

--- a/packages/vite-bundler/build.ts
+++ b/packages/vite-bundler/build.ts
@@ -143,6 +143,10 @@ function transpileViteBundle({ payload }: Pick<ViteBundleOutput, 'payload'>) {
       babelOptions.babelrc = true
       babelOptions.sourceMaps = true
       babelOptions.filename = babelOptions.sourceFileName = from
+      babelOptions.caller = babelOptions.caller || {
+        name: 'meteor-vite',
+        arch: 'web.browser.vite',
+      }
       const transpiled = Babel.compile(source, babelOptions, {
         cacheDirectory: path.join(cwd, 'node_modules', '.babel-cache'),
       })

--- a/packages/vite-bundler/types/global.d.ts
+++ b/packages/vite-bundler/types/global.d.ts
@@ -24,6 +24,7 @@ declare global {
             sourceMaps: boolean;
             filename: string;
             sourceFileName: string;
+            caller?: Record<string, unknown>;
         };
         function compile(source: string, compileOptions: CompileOptions, babelOptions: object): {
             code: string;

--- a/pipeline-helpers.ts
+++ b/pipeline-helpers.ts
@@ -1,0 +1,194 @@
+import { PipelineContext } from './types';
+import type { Meteor, Subscription } from 'meteor/meteor';
+import type { Mongo } from 'meteor/mongo';
+
+type Step<I, R> = (this: Subscription | Meteor.MethodThisType, input: I, context: PipelineContext<unknown>) => R
+
+const Pipeline = Symbol('zodern:relay:pipeline');
+export const Subscribe = Symbol('zodern:relay:subscribe');
+
+export function partialPipeline<I, R1>(step1: Step<I, R1>): (input: I) => R1
+export function partialPipeline<I, R1, R2>(step1: Step<I, R1>, step2: Step<Awaited<R1>, R2>): (input: I) => R2
+export function partialPipeline<I, R1, R2, R3>(step1: Step<I, R1>, step2: Step<Awaited<R1>, R2>, step3: Step<Awaited<R2>, R3>): (input: I) => R3
+export function partialPipeline<I, R1, R2, R3, R4>(step1: Step<I, R1>, step2: Step<Awaited<R1>, R2>, step3: Step<Awaited<R2>, R3>, step4: Step<Awaited<R3>, R4>): (input: I) => R4
+export function partialPipeline<I, R1, R2, R3, R4, R5>(step1: Step<I, R1>, step2: Step<Awaited<R1>, R2>, step3: Step<Awaited<R2>, R3>, step4: Step<Awaited<R3>, R4>, step5: Step<Awaited<R4>, R5>): (input: I) => R5
+export function partialPipeline<I, R1, R2, R3, R4, R5, R6>(step1: Step<I, R1>, step2: Step<Awaited<R1>, R2>, step3: Step<Awaited<R2>, R3>, step4: Step<Awaited<R3>, R4>, step5: Step<Awaited<R4>, R5>, step6: Step<Awaited<R5>, R6>): (input: I) => R6
+export function partialPipeline(...steps: any[]): (input: any) => any {
+  const fn = (input: any) => {
+    throw new Error('partial pipelines should not be called directly');
+  };
+
+  (fn as any)[Pipeline] = steps;
+
+  return fn;
+}
+
+export function flattenPipeline(pipeline: any[]) {
+  let result: Function[] = [];
+
+  for (const step of pipeline) {
+    if (step[Pipeline]) {
+      result.push(...flattenPipeline(step[Pipeline]));
+    } else {
+      result.push(step);
+    }
+  }
+
+  return result;
+}
+
+export function isThenable(possiblePromise: any): possiblePromise is Promise<any> {
+  return possiblePromise && typeof possiblePromise.then === 'function';
+}
+
+export function withCursors<I extends object, T extends Record<string, Mongo.Cursor<any>>>(input: I, cursors: T):
+  I & { [K in keyof T]: T[K] extends Mongo.Cursor<infer X> ? X[] : never } {
+  let hasUpdate = false;
+  let updateInput = () => { hasUpdate = true };
+  let handles: Meteor.LiveQueryHandle[] = [];
+  let docs: {
+    [K in keyof T]: T[K] extends Mongo.Cursor<infer X> ? X[] : never
+  } = Object.entries(cursors).reduce((result: any, [name, cursor]) => {
+    result[name] = [];
+    let initialAdd = true;
+
+    let handle = cursor.observe({
+      addedAt(document, index) {
+        result[name].splice(index, 0, document);
+        if (!initialAdd) {
+          updateInput();
+        }
+      },
+      changedAt(doc, _old, index) {
+        result[name][index] = doc;
+        updateInput();
+      },
+      removedAt(_doc, index) {
+        result[name].splice(index, 1);
+        updateInput();
+      },
+      movedTo(_doc, fromIndex, toIndex) {
+        let [doc] = result[name].splice(fromIndex, 1);
+        // toIndex already accounted for removing the doc at fromIndex
+        // could change the toIndex
+        result[name].splice(toIndex, 0, doc);
+
+        // Don't update input since there will also be a
+        // call to changedAt to apply the changes that caused
+        // the document to move
+      }
+    });
+
+    initialAdd = false;
+    handles.push(handle);
+
+    return result;
+  }, {});
+
+  function createOutput() {
+    return Object.assign({}, input, docs);
+  }
+
+  let initialOutput = createOutput();
+  (initialOutput as any)[Subscribe] = function (_updateInput: (data: any) => void) {
+    updateInput = () => _updateInput(createOutput());
+    if (hasUpdate) {
+      updateInput();
+      hasUpdate = false;
+    }
+
+    return function stop() {
+      handles.forEach(handle => handle.stop());
+    }
+  }
+
+  return initialOutput;
+}
+
+export function createReactiveCursorPublisher(sub: Subscription) {
+  let handles: Meteor.LiveQueryHandle[] = [];
+  let publishedData: {
+    [key: string]: Map<string, any>
+  } = Object.create(null);
+
+  function updateCursors(cursors: Mongo.Cursor<any> []) {
+    handles.forEach(handle => handle.stop());
+
+    // Make sure no more than one per collection
+    let colls = new Set();
+    cursors.forEach(cursor => {
+      let coll = (cursor as any)._cursorDescription.collectionName;
+      if (colls.has(coll)) {
+        throw new Error(`Publishing more than one cursor for the collection: ${coll}`);
+      }
+
+      colls.add(coll);
+    });
+
+    let previouslyPublished = publishedData;
+    publishedData = Object.create(null);
+
+    // TODO: check if the cursors changed. If a cursor is the same, we could
+    // reuse the old handle
+    cursors.forEach(cursor => {
+      let coll = (cursor as any)._cursorDescription.collectionName;
+
+      let previousData = previouslyPublished[coll] || new Map();
+      delete previouslyPublished[coll];
+      let data = publishedData[coll] = new Map();
+
+      let handle = cursor.observeChanges({
+        added(id, fields) {
+          if (previousData.has(id)) {
+            // Some fields might no longer be part of the new cursor
+            // Set all old fields to undefined, and then override any
+            // that still exist with the new value
+            // Fields that are still undefined will be removed by Meteor
+            let prevFields = Object.keys(previousData.get(id))
+              .reduce<{ [key: string]: undefined }>((result, field) => {
+                result[field] = undefined;
+                return result;
+              }, {});
+            sub.changed(coll, id, Object.assign(prevFields, fields));
+            previousData.delete(id);
+          } else {
+            sub.added(coll, id, fields);
+          }
+
+          data.set(id, fields);
+        },
+        changed(id, fields) {
+          sub.changed(coll, id, fields);
+          let oldFields = data.get(id);
+          // TODO: do we need to clone oldFields?
+          data.set(id, Object.assign({}, oldFields, fields));
+        },
+        removed(id) {
+          sub.removed(coll, id);
+          data.delete(id);
+        }
+      });
+
+      // Remove docs that are no longer found by the new cursor
+      for (const id of previousData.keys()) {
+        sub.removed(coll, id);
+      }
+
+      handles.push(handle);
+    });
+
+    Object.entries(previouslyPublished).forEach(([ coll, docs]) => {
+      for (const id of docs.keys()) {
+        sub.removed(coll, id);
+      }
+    });
+
+    sub.ready();
+  }
+
+  function stop() {
+    handles.forEach(handle => handle.stop());
+  }
+
+  return { updateCursors, stop };
+}

--- a/server-main.ts
+++ b/server-main.ts
@@ -1,0 +1,383 @@
+import type * as z from "zod";
+import type { Subscription } from 'meteor/meteor';
+import { Meteor } from 'meteor/meteor';
+import type { CreateMethodPipeline, CreatePubPipeline, PipelineContext, SubscriptionCallbacks } from './types'
+import { createReactiveCursorPublisher, flattenPipeline, isThenable, partialPipeline, Subscribe, withCursors } from './pipeline-helpers';
+
+export type { PipelineContext };
+
+export { partialPipeline, withCursors };
+
+let globalMethodPipeline: any[] = [];
+let globalPublicationPipeline: any[] = [];
+
+export function setGlobalMethodPipeline (
+  ...pipeline: ((this: Meteor.MethodThisType, input: any, context: PipelineContext<any>) => {})[]
+) {
+  if (globalMethodPipeline.length > 0) {
+    throw new Error('Global method pipeline already configured');
+  }
+
+  globalMethodPipeline = pipeline;
+}
+
+export function setGlobalPublicationPipeline(
+  ...pipeline: ((this: Subscription, input: any, context: PipelineContext<any>) => {})[]
+) {
+  if (globalPublicationPipeline.length > 0) {
+    throw new Error('Global publication pipeline already configured');
+  }
+
+  globalPublicationPipeline = pipeline;
+}
+
+export function createMethod <S extends z.ZodTypeAny, T > (
+  config: {
+    name?: string, schema: S,
+    rateLimit ?: { interval: number, limit: number },
+    stub?: boolean | ((this: Meteor.MethodThisType, args: z.output<S>) => any),
+    run: (this: Meteor.MethodThisType, args: z.output<S>) => T }
+): (...args: S extends z.ZodUndefined ? [] : [z.input<S>]) => Promise<T>
+export function createMethod <S extends z.ZodTypeAny>(
+  config: { name?: string, schema: S, rateLimit ?: { interval: number, limit: number } }
+) : { pipeline: CreateMethodPipeline<z.output<S>> }
+export function createMethod<S extends z.ZodUndefined | z.ZodTypeAny, T>(config: {
+  name?: string;
+  schema: S,
+  stub?: any, 
+  rateLimit?: {
+    interval: number,
+    limit: number
+  },
+  run?: ((this: Meteor.MethodThisType, args: z.output<S>) => T)
+}): any {
+  let pipeline: any = [];
+
+  if (typeof config.run === 'function') {
+    pipeline = [config.run];
+  }
+
+  // The name isn't actually optional, but the babel plugin will
+  // add a name if there isn't one
+  if (!config.name) {
+    throw new Error(`Method name is missing. Do you have the relay babel plugin configured?`);
+  }
+
+  let name = config.name;
+
+  Meteor.methods({
+    [name](data) {
+      if (pipeline.length === 0) {
+        throw new Error(`Pipeline or run function for ${name} never configured`);
+      }
+
+      let onResult: ((value: any) => void)[] = [];
+      let onError: ((err: any) => any)[] = [];
+
+      let self = this;
+      let parsed: z.output<S> = config.schema.parse(data);
+
+      let context: PipelineContext<z.output<S>> = {
+        originalInput: parsed,
+        type: 'method',
+        name,
+        onResult(callback: (result: any) => void) {
+          onResult.push(callback);
+        },
+        onError(callback: (error: any) => any) {
+          onError.push(callback);
+        },
+        stop() {
+          // TODO: support stop in methods
+          throw new Error('stop should not be called in methods');
+        }
+      }
+
+      async function run() {
+        let input: any = parsed;
+        let fullPipeline = [...globalMethodPipeline, ...pipeline];
+
+        for (const func of fullPipeline) {
+          input = func.call(self, input, context);
+          if (isThenable(input)) {
+            input = await input;
+          }
+        }
+
+        return input;
+      }
+
+      try {
+        let result = (Promise as any).await(run());
+
+        onResult.forEach(callback => {
+          callback(result);
+        });
+
+        return result;
+      } catch (error) {
+        error = onError.reduce((err, callback) => {
+          return callback(err) ?? err;
+        }, error);
+
+        throw error;
+      }
+    }
+  });
+
+  if (config.rateLimit) {
+    DDPRateLimiter.addRule({
+      type: 'method',
+      name,
+      clientAddress() { return true },
+      connectionId() { return true },
+      userId() { return true },
+    }, config.rateLimit.limit, config.rateLimit.interval);
+  }
+
+  function call(args?: z.input<S>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      Meteor.call(name, args, (err: null | Meteor.Error, result: T) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  }
+
+  call.config = config;
+
+  if (config.run) {
+    return call;
+  }
+
+  return {
+    pipeline(..._pipeline: any[]) {
+      pipeline = flattenPipeline(_pipeline);
+      return call;
+    }
+  };
+}
+
+export function createPublication<S extends z.ZodTypeAny, T>(config: { name?: string | null, schema: S, rateLimit?: { interval: number, limit: number }, run: (this: Subscription, args: z.output<S>) => T }): (...args: z.output<S> extends undefined ? [SubscriptionCallbacks?] : [z.output<S>, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle
+export function createPublication<S extends z.ZodTypeAny, R1,> (config: { name?: string | null, schema: S, rateLimit ?: { interval: number, limit: number } }): { pipeline: CreatePubPipeline<z.output<S>> }
+export function createPublication<S extends z.ZodTypeAny, T>(
+  config: { name?: string | null, schema: S, rateLimit?: { interval: number, limit: number }, run?: ((this: Subscription, args: z.output<S>) => T) }
+): any {
+  let pipeline: any = config.run;
+
+  if (typeof config.run === 'function') {
+    pipeline = [config.run];
+  }
+
+  // The name isn't actually optional, but the babel plugin will
+  // add a name if there isn't one
+  if (typeof config.name === 'undefined') {
+    throw new Error(`Publication name is missing. Do you have the relay babel plugin configured?`);
+  }
+
+  let name = config.name;
+
+  Meteor.publish(name, function (data: z.input<S>) {
+    if (pipeline.length === 0) {
+      throw new Error(`Pipeline or run function never configured for ${name} publication`);
+    }
+
+    let fullPipeline = [...globalPublicationPipeline, ...pipeline];
+
+    let self = this;
+    let parsed: z.output<S> = config.schema.parse(data);
+    let stopPipelineSubscriptions: (() => void)[] = [];
+
+    let reactivePublisher = createReactiveCursorPublisher(self);
+
+    let dirty: { index: number, input: any } | null = null;
+    let isRunning = false;
+    let pipelineStopped = false;
+
+    this.onStop(() => {
+      pipelineStopped = true;
+      stop();
+    });
+
+    function stop() {
+      stopPipelineSubscriptions.forEach((func) => func && func());
+      reactivePublisher.stop();
+    }
+
+    function markDirty(index: number, input: any) {
+      if (dirty) {
+        if (index < dirty.index) {
+          dirty.index = index;
+          dirty.input = input;
+        }
+        return;
+      }
+
+      dirty = {
+        index,
+        input
+      };
+
+      if (!isRunning) {
+        Meteor.defer(runFromDirty);
+      }
+    }
+
+    function runFromDirty() {
+      let dirtyTmp = dirty;
+      dirty = null;
+
+      if (dirtyTmp === null) {
+        throw new Error('Tried to run pipeline, but not dirty?');
+      }
+
+      run(dirtyTmp.index, dirtyTmp.input);
+    }
+
+    let onResult: ((result: any) => void)[] = [];
+    let onError: ((err: any) => any)[] = [];
+    let context: PipelineContext<z.output<S>> = {
+      originalInput: parsed,
+      type: 'publication',
+      name,
+      onResult(callback: (result: any) => void) {
+        onResult.push(callback);
+      },
+      onError(callback: (error: any) => any) {
+        onError.push(callback);
+      },
+      stop() {
+        pipelineStopped = true;
+        self.ready();
+
+        stopPipelineSubscriptions.forEach(func => func && func());
+        stopPipelineSubscriptions = [];
+      }
+    }
+
+    async function run(startIndex: number, startInput: any) {
+      if (isRunning) {
+        console.log('zodern:relay Tried to run pipeline while it is already running??');
+        return;
+      }
+
+      isRunning = true;
+      let input = startInput;
+
+      for (let index = startIndex; index < fullPipeline.length; index++) {
+        const func = fullPipeline[index];
+
+        let stopPrevious = stopPipelineSubscriptions[index];
+        if (stopPrevious) stopPrevious();
+
+        if (pipelineStopped) {
+          break;
+        }
+
+        input = func.call(self, input, context);
+        if (isThenable(input)) {
+          input = await input;
+        }
+
+        if (pipelineStopped) {
+          break;
+        }
+
+        if (input && input[Subscribe]) {
+          let stopSubscription = input[Subscribe]((newResult: any) => {
+            markDirty(index + 1, newResult);
+          });
+
+          stopPipelineSubscriptions[index] = stopSubscription;
+        }
+      }
+
+      isRunning = false;
+
+      if (pipelineStopped) {
+        return;
+      }
+
+      if (dirty) {
+        // TODO: it would be good if this waited a little bit
+        // before running again like markDirty does
+        runFromDirty();
+      }
+
+      let output = input;
+      let forwardOutput = false;
+
+      if (stopPipelineSubscriptions.length > 0) {
+        // The pipeline is reactive
+        // We have to handle publishing cursors ourselves
+
+        // Meteor checks for _publishedCursor to identify cursors
+        if (output && !Array.isArray(output) && output._publishCursor) {
+          reactivePublisher.updateCursors([output]);
+        } else if (Array.isArray(output) && output.every(c => c._publishCursor)) {
+          reactivePublisher.updateCursors(output);
+        }
+      } else {
+        forwardOutput = true;
+      }
+
+      return {
+        output,
+        forwardOutput
+      };
+    }
+
+    try {
+      const result = (Promise as any).await(run(0, parsed));
+
+      onResult.forEach(cb => {
+        cb(result.output);
+      });
+
+      return result.forwardOutput ? result.output : undefined;
+    } catch(error) {
+      error = onError.reduce((err, callback) => {
+        return callback(err) ?? err;
+      }, error);
+
+      throw error;
+    }
+  });
+
+  if (config.rateLimit) {
+    if (name === null) {
+      throw new Error('Cannot add rate limit for null publication');
+    }
+
+    DDPRateLimiter.addRule({
+      type: 'subscription',
+      name,
+      clientAddress() { return true },
+      connectionId() { return true },
+      userId() { return true },
+    }, config.rateLimit.limit, config.rateLimit.interval)
+  }
+
+  function subscribe(...args: S extends z.ZodUndefined ? [SubscriptionCallbacks?] : [z.input<S>, SubscriptionCallbacks?]): Meteor.SubscriptionHandle {
+    if (name === null) {
+      throw new Error('Cannot directly subscribe to null publication');
+    }
+    return Meteor.subscribe(name, args);
+  }
+
+  subscribe.config = config;
+
+  if (config.run) {
+    return subscribe;
+  }
+
+  return {
+    pipeline(..._pipeline: any[]) {
+      pipeline = flattenPipeline(_pipeline);
+      return subscribe;
+    }
+  };
+}

--- a/tests/.babelrc
+++ b/tests/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "../.babel-plugin/plugin.js"
+  ]
+}

--- a/tests/index.d.ts
+++ b/tests/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../server-main';

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -1,0 +1,284 @@
+import { expectError, expectType } from 'tsd';
+import { z } from 'zod';
+import { partialPipeline } from '../pipeline-helpers';
+import { createMethod, createPublication } from '../server-main';
+
+const undefinedMethod = createMethod({
+  name: 'test',
+  schema: z.undefined(),
+  run() {
+    return 5;
+  }
+});
+
+const objMethod = createMethod({
+  name: 'test2',
+  schema: z.object({
+    a: z.number(),
+    b: z.string()
+  }),
+  run() {
+    return true;
+  }
+});
+
+const stringMethod = createMethod({
+  name: 'test3',
+  schema: z.string(),
+  run() {
+    return 55;
+  }
+});
+
+const anyMethod = createMethod({
+  name: 'test4',
+  schema: z.any(),
+  run() {
+    return 'abc';
+  }
+});
+
+const pipelineMethod = createMethod({
+  name: 'test5',
+  schema: z.number(),
+}).pipeline(
+  (i) => i + 5,
+  (i) => i - 1,
+  (i) => i / 2
+);
+
+const asyncPipeline = createMethod({
+  name: 'test5',
+  schema: z.number()
+}).pipeline(
+  async (i) => i + 5,
+  (i) => i - 1,
+  (i) => i / 2
+);
+
+const partial = partialPipeline(
+  <I extends { a: number }>({ a }: I) => a,
+  (i) => i / 2,
+);
+
+const partialAsync = partialPipeline(
+  <I extends { a: number }>({ a }: I) => a,
+  async (i) => i / 2,
+  (i) => i
+);
+
+const partialBoolean = partialPipeline(
+  <I>(i: I) => i,
+  () => true
+)
+
+const subPipeline = partialPipeline(partialBoolean, reusableStep);
+
+const partialMethod = createMethod({
+  name: 'test6',
+  schema: z.object({ a: z.number(), b: z.string() })
+}).pipeline(
+  (input) => input,
+  (i) => i,
+  partial,
+  (i) => i,
+  );
+
+const subPartialMethod = createMethod({
+  name: 'subPartialMethod',
+  schema: z.string()
+}).pipeline(subPipeline, (i) => !i);
+
+function reusableStep<I>(input: I) {
+  return input;
+}
+
+const reusableMethod = createMethod({
+  name: 'test7',
+  schema: z.object({ a: z.number(), b: z.string() })
+}).pipeline(
+  (input) => input,
+  reusableStep,
+  (i) => i,
+);
+
+const undefinedPipeline = createMethod({
+  name: 'test8',
+  schema: z.undefined()
+}).pipeline(
+  () => 5
+);
+
+const stubMethod = createMethod({
+  name: 'test4',
+  schema: z.undefined(),
+  // stub() {
+  //   return 10 / 2
+  // },
+  run() {
+    return 5;
+  }
+});
+
+const stubMethod2 = createMethod({
+  name: 'test5',
+  schema: z.undefined(),
+  stub: true,
+  run() {
+    return 20;
+  }
+});
+
+expectType<Promise<number>>(undefinedMethod());
+expectError(undefinedMethod(5));
+
+expectType<Promise<boolean>>(objMethod({ a: 5, b: 'abc' }));
+expectError(objMethod());
+expectError(objMethod(5));
+
+expectType<Promise<number>>(stringMethod('fun'));
+expectError(stringMethod());
+expectError(stringMethod({ a: 20 }));
+
+expectType<Promise<string>>(anyMethod('123'));
+
+expectType<Promise<number>>(partialMethod({ a: 5, b: 'true' }));
+
+expectType<Promise<{ a: number, b: string }>>(reusableMethod({ a: 5, b: 'test' }));
+
+expectType<Promise<number>>(undefinedPipeline());
+expectError(undefinedMethod(5));
+
+expectType<Promise<boolean>>(subPartialMethod('fun'));
+
+// TODO: fix this
+// expectType<Promise<string>>(anyMethod());
+
+expectType<Promise<number>>(pipelineMethod(20));
+expectError(pipelineMethod('5'));
+
+expectType<Promise<number>>(asyncPipeline(20));
+
+expectType<number>(partial({ a: 5 }));
+expectError(partial({ a: 'a' }));
+
+expectType<number>(partialAsync({ a: 5 }));
+
+expectType<(s: string) => Promise<string | null>>(createMethod({
+  name: 'fun',
+  schema: z.string()
+}).pipeline(
+  (input, context) => context.name,
+  (input, context) => {
+    context.onError((err: any) => new Error('test'));
+    context.onResult((result: any) => console.log(result));
+    context.type.substring(0, 5);
+
+    return input;
+  }
+));
+
+expectType<(s: string) => Promise<string>>(createMethod({
+  name: 'fun',
+  schema: z.string()
+}).pipeline(
+  (input) => true,
+  (input, context) => {
+    return context.originalInput
+  }
+));
+
+expectType<Promise<number>>(stubMethod(5));
+expectType<Promise<number>>(stubMethod2());
+expectError(createMethod({
+  schema: z.number(),
+  stub: true
+}));
+
+expectError(createMethod({
+  schema: z.number(),
+  stub() {
+    return 5;
+  }
+}));
+
+
+const undefinedSubscribe = createPublication({
+  name: 'test',
+  schema: z.undefined(),
+  run() {
+  }
+});
+
+const objSubscribe = createPublication({
+  name: 'test2',
+  schema: z.object({
+    a: z.number(),
+    b: z.string()
+  }),
+  run() {
+  }
+});
+
+const stringSubscribe = createPublication({
+  name: 'test3',
+  schema: z.string(),
+  run() {
+  }
+});
+
+const anySubscribe = createPublication({
+  name: 'test4',
+  schema: z.any(),
+  run() {
+  }
+});
+
+expectType<Meteor.SubscriptionHandle>(undefinedSubscribe());
+expectError(undefinedSubscribe(5));
+
+expectType<Meteor.SubscriptionHandle>(objSubscribe({ a: 5, b: 'abc' }));
+expectError(objSubscribe());
+expectError(objSubscribe(5));
+
+expectType<Meteor.SubscriptionHandle>(stringSubscribe('fun'));
+expectError(stringSubscribe());
+expectError(stringSubscribe({ a: 20 }));
+
+expectType<Meteor.SubscriptionHandle>(anySubscribe('123'));
+// TODO: fix this
+// expectType<Meteor.SubscriptionHandle>(anySubscribe());
+
+expectType<Meteor.SubscriptionHandle>(stringSubscribe('fun2', {
+  onStop(err: Error) {
+    console.log(err);
+  }
+}));
+
+expectType<Meteor.SubscriptionHandle>(stringSubscribe('fun3', {
+  onReady() {
+    console.log('ready');
+  }
+}));
+
+expectType<Meteor.SubscriptionHandle>(undefinedSubscribe({
+  onReady() {
+    console.log('ready');
+  }
+}));
+
+expectType<Meteor.SubscriptionHandle>(stringSubscribe('fun3', {}));
+
+expectType<Meteor.SubscriptionHandle>(createPublication({
+  name: 'fun',
+  schema: z.string()
+}).pipeline(
+  (input, context) => context.name,
+  (input, context) => {
+    context.onError((err: any) => new Error('test'));
+    context.onResult((result: any) => console.log(result));
+    context.type.substring(0, 5);
+
+    return input;
+  }
+)('test'));

--- a/tests/method-tests.js
+++ b/tests/method-tests.js
@@ -1,0 +1,153 @@
+const {
+  schema,
+  run,
+  test1,
+  rateLimited,
+  errorMethod,
+  wait100,
+  fastMethod,
+  configMethod,
+  simplePipeline,
+  asyncPipeline,
+  methodUnblock,
+  partialMethod,
+  contextMethod,
+  getEvents,
+  contextFailedMethod,
+  globalPipelineMethod,
+  unnamedMethod,
+  stubMethod,
+  stubRunMethod
+} = require('./methods/index.js');
+
+Tinytest.addAsync('methods - basic', async (test) => {
+  const result = await test1();
+  test.equal(result, 5);
+});
+
+Tinytest.addAsync('methods - error', async (test) => {
+  try {
+    await errorMethod();
+    test.equal('should never be reached', true);
+  } catch (e) {
+    test.equal(e.message, '[test error]');
+  }
+});
+
+Tinytest.addAsync('methods - unblock', async (test) => {
+  const result = await methodUnblock(5);
+  test.equal(result, undefined);
+});
+
+if (Meteor.isServer) {
+  Tinytest.add('methods - config server', async (test) => {
+    test.equal(configMethod.config.name, 'a');
+    test.equal(configMethod.config.schema, schema);
+    test.equal(configMethod.config.run, run);
+  });
+} else {
+  Tinytest.add('methods - config client', async (test) => {
+    test.equal(Object.keys(test1.config), ['name']);
+    test.equal(test1.config.name, 'test1');
+  });
+}
+
+if (Meteor.isClient) {
+  Tinytest.addAsync('methods - rate limit', async (test) => {
+    for (let i = 0; i < 5; i++) {
+      await rateLimited();
+    }
+
+    try {
+      await rateLimited();
+      test.equal('should never be reached', true);
+    } catch (e) {
+      test.equal(e.error, 'too-many-requests');
+    }
+  });
+}
+
+Tinytest.addAsync('methods - async block by default', async (test) => {
+  let order = [];
+
+  await Promise.all([
+    wait100().then(() => order.push('wait100')),
+    fastMethod().then(() => order.push('fastMethod'))
+  ]);
+
+  test.equal(order, ['wait100', 'fastMethod']);
+});
+
+if (Meteor.isClient) {
+  Tinytest.add('methods - error if created on client', (test) => {
+    try {
+      require('./methods.js');
+      test.equal('should never be reached', true);
+    } catch (e) {
+      test.equal(e.message, 'createMethod should never be called on the client.\nEnsure you have @zodern/babel-plugin-meteor-reify configured, or\nyou are calling createMethod only in files inside a methods directory')
+    }
+  });
+}
+
+Tinytest.addAsync('methods - pipeline', async (test) => {
+  const result = await simplePipeline(10)
+
+  test.equal(result, 14.5);
+});
+
+Tinytest.addAsync('methods - async pipeline', async (test) => {
+  const result = await asyncPipeline(10)
+
+  test.equal(result, 14.5);
+});
+
+Tinytest.addAsync('methods - partial pipeline', async (test) => {
+  const result = await partialMethod(3.33)
+
+  test.equal(result, '6.7');
+});
+
+Tinytest.addAsync('methods - context success', async (test) => {
+  const result = await contextMethod(5);
+  test.equal(result, true);
+
+  const events = await getEvents();
+  test.equal(events, ['result: true']);
+});
+
+
+Tinytest.addAsync('methods - context error', async (test) => {
+  try {
+    await contextFailedMethod(5);
+    test.equal('should never be reached', true);
+  } catch (e) {
+    test.equal(e.message, '[second err]');
+  }
+
+  const events = await getEvents();
+  test.equal(events, ['first err', 'first err']);
+});
+
+Tinytest.addAsync('methods - global pipeline', async (test) => {
+  const result = await globalPipelineMethod(5);
+  test.equal(result, 6);
+});
+
+Tinytest.addAsync('methods - unnamed method', async (test) => {
+  const result = await unnamedMethod(10);
+  test.equal(result, 5);
+});
+
+if (Meteor.isClient) {
+  Tinytest.addAsync('methods - run as stub', async (test) => {
+    window.stub = false;
+    stubRunMethod(10);
+    test.equal(window.stub, true);
+  });
+
+  Tinytest.addAsync('methods - stub method', async (test) => {
+    window.stub = false;
+    stubMethod(10);
+    test.equal(window.stub, true);
+  });
+}

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -1,0 +1,5 @@
+const { createMethod } = require('meteor/zodern:relay');
+
+createMethod({
+  name: 'test'
+});

--- a/tests/methods/index.js
+++ b/tests/methods/index.js
@@ -1,0 +1,251 @@
+const { z } = require('zod');
+import { createMethod, partialPipeline, setGlobalMethodPipeline } from 'meteor/zodern:relay';
+import assert from 'assert';
+
+export const test1 = createMethod({
+  name: 'test1',
+  schema: z.any(),
+  run() {
+    return 5;
+  }
+});
+
+export const errorMethod = createMethod({
+  name: 'errorMethod',
+  schema: z.any(),
+  run() {
+    throw new Meteor.Error('test error');
+  }
+});
+
+export const methodUnblock = createMethod({
+  name: 'methodUnblock',
+  schema: z.number(),
+  run() {
+    this.unblock();
+  }
+})
+
+export const schema = z.any();
+export function run() { };
+
+export const configMethod = createMethod({
+  name: 'a',
+  schema,
+  run
+});
+
+export const rateLimited = createMethod({
+  name: 'rateLimited',
+  schema: z.any(),
+  rateLimit: {
+    interval: 1000,
+    limit: 5
+  },
+  run() {
+    return true;
+  }
+});
+
+export const wait100 = createMethod({
+  name: 'wait100',
+  schema: z.any(),
+  async run() {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return true;
+  }
+});
+
+export const fastMethod = createMethod({
+  name: 'fast',
+  schema: z.any(),
+  async run() {
+    return 5;
+  }
+});
+
+export const simplePipeline = createMethod({
+  name: 'simplePipeline',
+  schema: z.number(),
+}).pipeline(
+    (n) => n + 5,
+    (n) => n - 1,
+    (n) => n + 0.5
+);
+
+export const asyncPipeline = createMethod({
+  name: 'asyncPipeline',
+  schema: z.number()
+}).pipeline(
+  async (n) => n + 5,
+  (n) => Promise.resolve(n - 1),
+  async (n) => n + 0.5
+);
+
+const partial = partialPipeline(
+  (i) => i + 10,
+  (i) => i / 2
+);
+
+const partial2 = partialPipeline(partial);
+
+export const partialMethod = createMethod({
+  name: 'partial',
+  schema: z.number()
+}).pipeline(
+  partial2,
+  (i) => i.toFixed(1)
+);
+
+export const contextMethod = createMethod({
+  name: 'context',
+  schema: z.number()
+}).pipeline(
+  (input, context) => {
+    resetEvents();
+    return true
+  },
+  (input, context) => {
+    assert.equal(input, true);
+    assert.equal(typeof context.originalInput, 'number');
+    assert.equal(context.type, 'method');
+    assert.equal(context.name, 'context');
+
+    context.onResult(r => {
+      events.push(`result: ${r}`);
+    });
+
+    return input;
+  }
+);
+
+export const contextFailedMethod = createMethod({
+  name: 'contextFailedMethod',
+  schema: z.number()
+}).pipeline(
+  (input, context) => {
+    resetEvents();
+    context.onError(err => {
+      events.push(err.message);
+    });
+    context.onError(err => {
+      events.push(err.message);
+      return new Meteor.Error('second err');
+    });
+    context.onResult(() => {
+      events.push('result');
+    });
+  },
+  () => {
+    throw new Error('first err');
+  }
+);
+
+setGlobalMethodPipeline(
+  (input, context) => {
+    if (context.name === 'globalPipelineMethod') {
+      return input + 1;
+    }
+
+    return input;
+  }
+);
+
+export const globalPipelineMethod = createMethod({
+  name: 'globalPipelineMethod',
+  schema: z.number(),
+  run(input) {
+    return input;
+  }
+});
+
+export const unnamedMethod = createMethod({
+  schema: z.number(),
+  run(input) {
+    return input / 2;
+  }
+});
+
+export const stubRunMethod = createMethod({
+  schema: z.number(),
+  stub: true,
+  run(input) {
+    if (Meteor.isClient) {
+      window.stub = true;
+    }
+    return input / 2;
+  }
+});
+
+export const stubMethod = createMethod({
+  schema: z.number(),
+  stub: true,
+  run(input) {
+    if (Meteor.isClient) {
+      window.stub = true;
+    }
+    return input / 2;
+  }
+});
+
+// Used for publication tests
+
+export const Numbers = new Mongo.Collection('numbers');
+export const Selected = new Mongo.Collection('selected');
+
+Numbers.remove({});
+Selected.remove({});
+
+for(let i = 0; i < 100; i++) {
+  Numbers.insert({ num: i });
+}
+
+let events = [];
+
+export function recordEvent(text) {
+  events.push(text);
+}
+
+export function resetEvents() {
+  events = [];
+}
+
+export const getEvents = createMethod({
+  name: 'getEvents',
+  schema: z.undefined(),
+  run() {
+    return events;
+  }
+});
+
+export const addSelected = createMethod({
+  name: 'addSelected',
+  schema: z.number(),
+  run(num) {
+    return Selected.insert({
+      _id: num.toString(),
+      num
+    });
+  }
+});
+
+export const removeSelected = createMethod({
+  name: 'removeSelected',
+  schema: z.string(),
+  run(id) {
+    return Selected.remove({
+      _id: id
+    });
+  }
+});
+
+export const updateSelected = createMethod({
+  name: 'updateSelected',
+  schema: z.object({ id: z.string(), num: z.number() }),
+  run({ id, num }) {
+    return Selected.update(
+      { _id: id },
+      { $set: { num } }
+    );
+  }
+});

--- a/tests/publication-tests.js
+++ b/tests/publication-tests.js
@@ -1,0 +1,211 @@
+import {
+  globalPipelinePub,
+  reactiveSubscribe,
+  subscribeBasic, subscribeContext, subscribeError, subscribeFailedContext, subscribeFast, subscribePartial, subscribePipeline, subscribeRateLimited, subscribeSlow, unnamedSubscribe
+} from './publications/index';
+import {
+  createPublication
+} from 'meteor/zodern:relay';
+import { addSelected, getEvents, removeSelected, updateSelected } from './methods/index';
+
+Tinytest.addAsync('publications - basic', (test, done) => {
+  let sub = subscribeBasic({
+    onReady() {
+      sub.stop();
+      done();
+    }
+  });
+});
+
+Tinytest.addAsync('publications - error', (test, done) => {
+  let sub = subscribeError({
+    onStop(err) {
+      test.equal(err.message, '[pub err]');
+      done();
+    }
+  });
+});
+
+Tinytest.addAsync('publications - args with options', (test, done) => {
+  let sub = subscribeBasic(
+    'input',
+    {
+      onReady() {
+        sub.stop();
+        done();
+      }
+    });
+});
+
+Tinytest.add('publications - config client', async (test) => {
+  test.equal(Object.keys(subscribeBasic.config), ['name']);
+  test.equal(subscribeBasic.config.name, 'basic');
+});
+
+Tinytest.addAsync('publications - rate limit', (test, done) => {
+  for (let i = 0; i < 5; i++) {
+    subscribeRateLimited();
+  }
+
+  subscribeRateLimited({
+    onStop(err) {
+      test.equal(err.error, 'too-many-requests');
+      done()
+    }
+  });
+});
+
+Tinytest.addAsync('publications - async block by default', (test, done) => {
+  let order = [];
+
+  subscribeSlow({
+    onReady() {
+      order.push('slow')
+    }
+  });
+
+  subscribeFast({
+    onReady() {
+      order.push('fast');
+      test.equal(order, ['slow', 'fast']);
+      done();
+    }
+  });
+});
+
+Tinytest.addAsync('publications - error if created on client', (test, done) => {
+  try {
+    createPublication({
+      name: 'test'
+    });
+  } catch (e) {
+    test.equal(e.message, `createPublication should never be called on the client.
+Ensure you have @zodern/babel-plugin-meteor-reify configured, or
+you are calling createPublication only in files inside a publications directory`);
+    done();
+  }
+});
+
+Tinytest.addAsync('publications - pipeline', (test, done) => {
+  let sub = subscribePipeline(
+    10,
+    {
+      async onReady() {
+        sub.stop();
+        let events = await getEvents();
+        test.equal(events, ['input: 10', 'complete: 20'])
+        done();
+      }
+    });
+});
+
+Tinytest.addAsync('publications - partial', (test, done) => {
+  let sub = subscribePartial(
+    3.33,
+    {
+      async onReady() {
+        sub.stop();
+        let events = await getEvents();
+        test.equal(events, ['complete: 6.7'])
+        done();
+      }
+    });
+});
+
+Tinytest.addAsync('publications - context', (test, done) => {
+  let sub = subscribeContext(
+    3.33,
+    {
+      async onReady() {
+        sub.stop();
+        let events = await getEvents();
+        test.equal(events, ['result: []'])
+        done();
+      }
+    });
+});
+
+Tinytest.addAsync('publications - context onError', (test, done) => {
+  let sub = subscribeFailedContext(
+    3.33,
+    {
+     async onStop(err) {
+        test.equal(err.message, '[second err]');
+
+        let events = await getEvents();
+        test.equal(events, ['first err', 'first err', '[second err]']);
+        done();
+      }
+    });
+});
+
+Tinytest.addAsync('publications - global pipeline', (test, done) => {
+  let sub = globalPipelinePub(
+    10,
+    {
+      async onReady() {
+        sub.stop();
+        let events = await getEvents();
+        test.equal(events, ['input: 11']);
+        done();
+      }
+    });
+});
+
+Tinytest.addAsync('publications - unnamed', (test, done) => {
+  let sub = unnamedSubscribe(
+    {
+      async onReady() {
+        sub.stop();
+        done();
+      }
+    });
+});
+
+let Numbers = new Mongo.Collection('numbers');
+
+Tinytest.addAsync('publications - reactive - basic', (test, done) => {
+  async function checkPublished(expected) {
+    let attempts = 0;
+    let published;
+
+    // Wait until sub sends changes
+    while (attempts < 5) {
+      published = Numbers.find().fetch().map(s => s.num);
+      if (
+        published.length === expected.length &&
+        published.every((v, index) => v === expected[index])
+      ) {
+        break;
+      }
+      attempts += 1;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+
+    test.equal(published, expected);
+  }
+  async function ready() {
+    await checkPublished([]);
+    let id = await addSelected(5);
+    await checkPublished([5]);
+    await addSelected(6);
+    await checkPublished([5, 6]);
+    await updateSelected({ id, num: 7 });
+    await checkPublished([6, 7]);
+    await removeSelected(id);
+    await checkPublished([6]);
+    let events = await getEvents();
+    test.equal(events, [
+      "Run Selectors step",
+      "Selected: ",
+      "Selected: 5 - 5",
+      "Selected: 5 - 5, 6 - 6",
+      "Selected: 6 - 6, 5 - 7",
+      "Selected: 6 - 6"
+    ]);
+    sub.stop();
+    done();
+  }
+
+  let sub = reactiveSubscribe({ onReady: ready });
+});

--- a/tests/publications/index.js
+++ b/tests/publications/index.js
@@ -1,0 +1,187 @@
+import { createPublication, withCursors, partialPipeline, setGlobalPublicationPipeline } from 'meteor/zodern:relay';
+import { Numbers, recordEvent, resetEvents, Selected } from '../methods/index';
+const { z } = require('zod');
+import assert from 'assert';
+
+export const subscribeBasic = createPublication({
+  name: 'basic',
+  schema: z.any(),
+  run() {
+    return []
+  }
+});
+
+export const subscribeError = createPublication({
+  name: 'error',
+  schema: z.any(),
+  run() {
+    throw new Meteor.Error('pub err');
+  }
+});
+
+export const subscribeRateLimited = createPublication({
+  name: 'rateLimited',
+  schema: z.any(),
+  rateLimit: {
+    interval: 1000,
+    limit: 5
+  },
+  run() {
+    return [];
+  }
+});
+
+export const subscribeSlow = createPublication({
+  name: 'slow',
+  schema: z.any(),
+  async run() {
+    await new Promise(resolve => setTimeout(resolve, 100));
+    return [];
+  }
+});
+
+
+export const subscribeFast = createPublication({
+  name: 'fast',
+  schema: z.any(),
+  async run() {
+    return [];
+  }
+});
+
+export const subscribePipeline = createPublication({
+  name: 'pipeline',
+  schema: z.number(),
+  run: [
+    (i) => {
+      resetEvents();
+      recordEvent(`input: ${i}`);
+      return i
+    },
+    async (i) => i + 10,
+    (i) => {
+      recordEvent(`complete: ${i}`);
+      return []
+    }
+  ]
+});
+
+const partial = partialPipeline(
+  (i) => i + 10,
+  (i) => i / 2
+)
+
+export const subscribePartial = createPublication({
+  name: 'partial',
+  schema: z.number()
+}).pipeline(
+  (i) => {
+    resetEvents();
+    return i;
+  },
+  partial,
+  (i) => i.toFixed(1),
+  (i) => recordEvent(`complete: ${i}`),
+  () => []
+);
+
+export const subscribeContext = createPublication({
+  name: 'context',
+  schema: z.number()
+}).pipeline(
+  (input, context) => {
+    resetEvents();
+    return true
+  },
+  (input, context) => {
+    assert.equal(input, true);
+    assert.equal(typeof context.originalInput, 'number');
+    assert.equal(context.type, 'publication');
+    assert.equal(context.name, 'context');
+
+    context.onResult(r => {
+      recordEvent(`result: ${JSON.stringify(r)}`);
+    });
+
+    return [];
+  }
+);
+
+export const subscribeFailedContext = createPublication({
+  name: 'contextFailed',
+  schema: z.number()
+}).pipeline(
+  (input, context) => {
+    resetEvents();
+    context.onError(err => {
+      recordEvent(err.message);
+    });
+    context.onError(err => {
+      recordEvent(err.message);
+      return new Meteor.Error('second err');
+    });
+    context.onError(err => {
+      recordEvent(err.message);
+    });
+    context.onResult(() => {
+      recordEvent('result');
+    });
+  },
+  () => {
+    throw new Error('first err');
+  }
+);
+
+setGlobalPublicationPipeline(
+  (input, context) => {
+    if (context.name === 'globalPipelinePub') {
+      return input + 1;
+    }
+
+    return input;
+  }
+);
+
+export const globalPipelinePub = createPublication({
+  name: 'globalPipelinePub',
+  schema: z.number(),
+  run(input) {
+    resetEvents();
+    recordEvent(`input: ${input}`);
+
+    return [];
+  }
+});
+
+export const reactiveSubscribe = createPublication({
+  name: 'reactivePub',
+  schema: z.undefined(),
+}).pipeline(
+  () => {
+    Selected.remove({});
+    resetEvents();
+  },
+  () => {
+    recordEvent('Run Selectors step');
+    return withCursors({}, {
+      selected: Selected.find({}, { sort: { num: 1 } })
+    });
+  },
+  ({ selected }) => {
+    let selectedDescription = selected.map(s => {
+      return `${s._id} - ${s.num}`;
+    }).join(', ');
+    recordEvent(`Selected: ${selectedDescription}`);
+
+    return Numbers.find({
+      num: { $in: selected.map(s => s.num )}
+    });
+  }
+);
+
+export const unnamedSubscribe = createPublication({
+  schema: z.undefined(),
+  run() {
+    return []
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "lib": [
+      "DOM",
+      "ES2019"
+    ],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2019"
+  },
+  "files": [
+    "./server-main.ts",
+    "./client-main.ts"
+  ]
+}

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,37 @@
+import type { Subscription, Meteor } from 'meteor/meteor';
+
+export interface SubscriptionCallbacks {
+  onStop?: (err?: any) => void,
+  onReady?: () => void
+}
+
+export interface PipelineContext<T> {
+  originalInput: T,
+  type: 'method' | 'publication',
+  name: string | null;
+  onError: (err: any) => any;
+  onResult: (result: any) => void;
+  stop: () => void;
+}
+
+export interface CreateMethodPipeline<I, This = Meteor.MethodThisType> {
+  <R1>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1): (...args: I extends undefined ? [] : [I]) => Promise<R1>;
+  <R1, R2>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1, fn2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2,): (...args: I extends undefined ? [] : [I]) => Promise<R2>;
+  <R1, R2, R3>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1, fn2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, fn3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3): (...args: I extends undefined ? [] : [I]) => Promise<R3>;
+  <R1, R2, R3, R4>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1, fn2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, fn3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, fn4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4): (...args: I extends undefined ? [] : [I]) => Promise<R4>;
+  <R1, R2, R3, R4, R5>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1, fn2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, fn3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, fn4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4, fn5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5): (...args: I extends undefined ? [] : [I]) => Promise<R5>;
+  <R1, R2, R3, R4, R5, R6>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1, fn2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, fn3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, fn4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4, fn5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5, fn6: (this: This, input: Awaited<R5>, context: PipelineContext<I>) => R6): (...args: I extends undefined ? [] : [I]) => Promise<R6>;
+  <R1, R2, R3, R4, R5, R6, R7>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1, fn2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, fn3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, fn4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4, fn5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5, fn6: (this: This, input: Awaited<R5>, context: PipelineContext<I>) => R6, fn7: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R7): (...args: I extends undefined ? [] : [I]) => Promise<R7>;
+  <R1, R2, R3, R4, R5, R6, R7, R8>(fn1: (this: This, input: I, context: PipelineContext<I>) => R1, fn2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, fn3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, fn4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4, fn5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5, fn6: (this: This, input: Awaited<R5>, context: PipelineContext<I>) => R6, fn7: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R7, fn8: (this: This, input: Awaited<R7>, context: PipelineContext<I>) => R8): (...args: I extends undefined ? [] : [I]) => Promise<R8>;
+} 
+
+export interface CreatePubPipeline<I, This = Subscription> {
+  <R1>(step1: (this: This, input: I, context: PipelineContext<I>) => R1): (...args: I extends undefined ? [] : [I]) => Promise<R1>;
+  <R1, R2>(step1: (this: This, input: I, context: PipelineContext<I>) => R1, step2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2,): (...args: I extends undefined ? [SubscriptionCallbacks?] : [I, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle
+  <R1, R2, R3>(step1: (this: This, input: I, context: PipelineContext<I>) => R1, step2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, step3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3): (...args: I extends undefined ? [SubscriptionCallbacks?] : [I, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle;
+  <R1, R2, R3, R4>(step1: (this: This, input: I, context: PipelineContext<I>) => R1, step2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, step3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, step4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4): (...args: I extends undefined ? [SubscriptionCallbacks?] : [I, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle;
+  <R1, R2, R3, R4, R5>(step1: (this: This, input: I, context: PipelineContext<I>) => R1, step2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, step3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, step4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4,step5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5): (...args: I extends undefined ? [SubscriptionCallbacks?] : [I, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle;
+  <R1, R2, R3, R4, R5, R6>(step1: (this: This, input: I, context: PipelineContext<I>) => R1, step2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, step3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, step4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4,step5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5,step6:  (this: This, input: Awaited<R5>, context: PipelineContext<I>) => R6): (...args: I extends undefined ? [SubscriptionCallbacks?] : [I, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle;
+  <R1, R2, R3, R4, R5, R6, R7>(step1: (this: This, input: I, context: PipelineContext<I>) => R1, step2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, step3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, step4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4,step5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5,step6:  (this: This, input: Awaited<R5>, context: PipelineContext<I>) => R6,step7:  (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R7): (...args: I extends undefined ? [SubscriptionCallbacks?] : [I, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle;
+  <R1, R2, R3, R4, R5, R6, R7, R8>(step1: (this: This, input: I, context: PipelineContext<I>) => R1, step2: (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R2, step3: (this: This, input: Awaited<R2>, context: PipelineContext<I>) => R3, step4: (this: This, input: Awaited<R3>, context: PipelineContext<I>) => R4,step5: (this: This, input: Awaited<R4>, context: PipelineContext<I>) => R5,step6:  (this: This, input: Awaited<R5>, context: PipelineContext<I>) => R6,step7:  (this: This, input: Awaited<R1>, context: PipelineContext<I>) => R7, step8: (this: This, input: Awaited<R7>, context: PipelineContext<I>) => R8): (...args: I extends undefined ? [SubscriptionCallbacks?] : [I, SubscriptionCallbacks?]) => Meteor.SubscriptionHandle;
+} 


### PR DESCRIPTION
Fixes:
- Works around an uncaught exception in `@zodern/babel-plugin-meteor-relay` when no caller arguments are provided to Babel. Issue ref: #182 
- Updated `@meteor-vite/plugin-zodern-relay` to skip unnecessary transpilation steps for modules that don't use `zodern:relay`.