### PR TITLE
Add option to build the Meteor server using Vite

### DIFF
--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -104,9 +104,6 @@ build() {
     (link) || exit 1
     (cleanOutput) || exit 1
 
-    ## Disable file watcher for meteor-vite npm package to prevent builds from hanging indefinitely
-    METEOR_VITE_TSUP_BUILD_WATCHER="false"
-
     cd "$APP_DIR" || exit 1
     meteor build "$BUILD_TARGET" --directory "$@"
 }

--- a/.bin/example-app.sh
+++ b/.bin/example-app.sh
@@ -28,7 +28,7 @@ METEOR_LOCAL_DIR_ROOT="/tmp/.meteor-local/meteor-vite/examples"
 METEOR_LOCAL_DIR="$METEOR_LOCAL_DIR_ROOT/$app"
 
 export METEOR_PACKAGE_DIRS="$PWD/packages:$PWD/test-packages/atmosphere"
-export METEOR_VITE_TSUP_BUILD_WATCHER="${METEOR_VITE_TSUP_BUILD_WATCHER:-'true'}"
+export METEOR_VITE_TSUP_BUILD_WATCHER="${METEOR_VITE_TSUP_BUILD_WATCHER:-true}"
 
 npmPackages=("meteor-vite" "@meteor-vite/plugin-zodern-relay")
 npmPackagesDir="$PWD/npm-packages"
@@ -51,8 +51,13 @@ PROD_MONGO_CONNECTION_URI="mongodb://127.0.0.1:$(($PROD_MONGO_METEOR_PORT + 1))/
 
 # Start a development server
 start() {
-  cd "$APP_DIR" || exit 1
-  $npm start -- "$@"
+  if [[ "$METEOR_VITE_TSUP_BUILD_WATCHER" == 'true' ]]; then
+     export METEOR_VITE_TSUP_BUILD_WATCHER="false"
+     npx concurrently -k -n "tsup,$app" -c dim,yellow "'npm:build:package -- -- --watch'" "'npm:start $app'"
+  else
+    cd "$APP_DIR" || exit 1
+    $npm start -- "$@"
+  fi
 }
 
 # Run a command in the context of the provided example app
@@ -163,7 +168,6 @@ link() {
 
   log:success "Linked ${npmPackages[*]} to $app"
 }
-
 
 production:install() {
    cd "$BUILD_TARGET/bundle/programs/server" || exit 1

--- a/.changeset/pink-baboons-serve.md
+++ b/.changeset/pink-baboons-serve.md
@@ -4,7 +4,41 @@
 ---
 
 Refactor IPC between Meteor and the Vite Dev Server to use DDP whenever possible.
-- Updated peer dependency for Vite to allow Vite v5. Meteor v2 users still need to use Vite v4 as v5 dropped support for Node v14 - the Node.js version used by Meteor. 
+- Updated peer dependency for Vite to allow Vite v5. Meteor v2 users still need to use Vite v4 as v5 dropped support for Node v14 - the Node.js version used by Meteor.
+
+### Build Meteor Server with Vite (experimental)
+Added an option to bundle the Meteor server with Vite. Bundles all your server assets into a single module before 
+passing it onto the Meteor compiler. This should significantly reduce the load on Meteor's dependency tracker, leading
+to much faster time-to-restart times in development.
+
+Also comes with the added flexibility provided by Vite and its plugin ecosystem. Lets you take full control over what
+code is imported on the server and how it's transformed.
+
+```ts
+// vite.config.ts
+export default defineConfig({
+    plugins: [
+        meteor({
+            clientEntry: './client/main.vite.ts',
+            serverEntry: './server/main.vite.ts', // Write your server code from this entrypoint.
+        })
+    ]
+});
+```
+
+```json5
+// package.json
+{
+  "meteor": {
+    "mainModule": {
+      "client": "./client/main.meteor.js",
+      // Create an empty main.meteor.js file in your server directory.
+      // This will be populated with your final Vite-built server bundle.
+      "server": "./server/main.meteor.js", 
+    }
+  }
+}
+```
 
 ### Compatability Notes
 - `jorgenvatle:vite-bundler` now requires `meteor-vite@ >= v1.11.0`.

--- a/.changeset/pink-baboons-serve.md
+++ b/.changeset/pink-baboons-serve.md
@@ -45,3 +45,7 @@ export default defineConfig({
 - This release only affects development builds. But it now assumes your development server is accessible locally over
 DDP. If you bind Meteor to an IP address that for some reason is not accessible to other processes, you may run into 
 issues where the Vite Dev Server won't start.
+
+### Resolves issues
+- #195
+- #179

--- a/.idea/meteor-vite.iml
+++ b/.idea/meteor-vite.iml
@@ -29,6 +29,7 @@
       <excludeFolder url="file://$MODULE_DIR$/npm-packages/meteor-vite/test/__mocks/meteor-bundle" />
       <excludeFolder url="file://$MODULE_DIR$/npm-packages/meteor-vite/test/__mocks/vite-output" />
       <excludeFolder url="file://$MODULE_DIR$/npm-packages/@meteor-vite/plugin-zodern-relay/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/examples/meteor-v3-vue/server/bundle" />
       <excludeFolder url="file://$MODULE_DIR$/examples/meteor-v3-vue/server/dist" />
       <excludePattern pattern=".babel-cache" />
       <excludePattern pattern="local" />

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -23,7 +23,7 @@
   "meteor": {
     "mainModule": {
       "client": "client/main.js",
-      "server": "server/main.ts"
+      "server": "server/main.js"
     },
     "testModule": "tests/main.js"
   },

--- a/examples/meteor-v3-vue/package.json
+++ b/examples/meteor-v3-vue/package.json
@@ -23,7 +23,7 @@
   "meteor": {
     "mainModule": {
       "client": "client/main.js",
-      "server": "server/main.ts",
+      "server": "server/main.js",
       "web.browser.legacy": "client/main.js"
     },
     "testModule": "tests/main.js"

--- a/examples/meteor-v3-vue/server/main.js
+++ b/examples/meteor-v3-vue/server/main.js
@@ -1,0 +1,1 @@
+import("./bundle/meteor.server").catch((e) => console.warn('Failed to load Vite server bundle. If this is the first time starting the server, you can safely ignore this error.', e))

--- a/examples/meteor-v3-vue/vite.config.ts
+++ b/examples/meteor-v3-vue/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
         vue(),
         meteor({
             clientEntry: 'imports/entrypoint/vite-client.ts',
+            serverEntry: 'server/main.ts',
         }),
         zodernRelay({
             directories: {

--- a/npm-packages/meteor-vite/src/VitePluginSettings.ts
+++ b/npm-packages/meteor-vite/src/VitePluginSettings.ts
@@ -12,6 +12,15 @@ export interface PluginSettings {
     clientEntry: string;
     
     /**
+     * Enter your Meteor server's entrypoint here to prebuild your Meteor server modules using Vite.
+     * This will not compile your Atmosphere packages, but will build all your app's server modules into
+     * a single file, greatly aiding Meteor in server reload performance during development.
+     *
+     * Not only does this come with improved performance, but also the flexibility of Vite's build system.
+     */
+    serverEntry?: string;
+    
+    /**
      * Skips bundling the provided npm packages if they are already provided by Meteor.
      * This assumes you have a Meteor package that depends on the provided npm packages.
      */

--- a/npm-packages/meteor-vite/src/VitePluginSettings.ts
+++ b/npm-packages/meteor-vite/src/VitePluginSettings.ts
@@ -1,5 +1,5 @@
 import { OutputOptions } from 'rollup';
-import { ResolvedConfig } from 'vite';
+import { ResolvedConfig, type UserConfig } from 'vite';
 import { DeepPartial, MakeOptional, type MakeRequired } from './utilities/GenericTypes';
 
 export interface PluginSettings {
@@ -19,6 +19,11 @@ export interface PluginSettings {
      * Not only does this come with improved performance, but also the flexibility of Vite's build system.
      */
     serverEntry?: string;
+    
+    /**
+     * Vite config overrides when bundling the Meteor server with Vite.
+     */
+    serverEntryConfig?: UserConfig;
     
     /**
      * Skips bundling the provided npm packages if they are already provided by Meteor.

--- a/npm-packages/meteor-vite/src/VitePluginSettings.ts
+++ b/npm-packages/meteor-vite/src/VitePluginSettings.ts
@@ -2,7 +2,7 @@ import { OutputOptions } from 'rollup';
 import { ResolvedConfig, type UserConfig } from 'vite';
 import { DeepPartial, MakeOptional, type MakeRequired } from './utilities/GenericTypes';
 
-export interface PluginSettings {
+export interface PluginSettings<TServerConfig extends UserConfig = {}> {
     /**
      * Vite client entry into Meteor.
      * Not to be confused with your Meteor mainModule.
@@ -23,7 +23,7 @@ export interface PluginSettings {
     /**
      * Vite config overrides when bundling the Meteor server with Vite.
      */
-    serverEntryConfig?: UserConfig;
+    serverEntryConfig?: TServerConfig;
     
     /**
      * Skips bundling the provided npm packages if they are already provided by Meteor.

--- a/npm-packages/meteor-vite/src/meteor/IPC/methods/build.ts
+++ b/npm-packages/meteor-vite/src/meteor/IPC/methods/build.ts
@@ -9,6 +9,7 @@ import {
     type MeteorStubsSettings,
 } from '../../../VitePluginSettings';
 import { meteorWorker } from '../../../plugin/Meteor';
+import { MeteorServerBuilder } from '../../ServerBuilder';
 import CreateIPCInterface, { IPCReply } from '../interface';
 
 type BuildOutput = Awaited<ReturnType<typeof build>>;
@@ -21,6 +22,9 @@ export default CreateIPCInterface({
         try {
             const { viteConfig, inlineBuildConfig, outDir } = await prepareConfig(buildConfig);
             const results = await build(inlineBuildConfig);
+            if (viteConfig.meteor?.serverEntry) {
+                await MeteorServerBuilder({ packageJson: buildConfig.packageJson, watch: false });
+            }
             const result = Array.isArray(results) ? results[0] : results;
             validateOutput(result);
 

--- a/npm-packages/meteor-vite/src/meteor/IPC/methods/build.ts
+++ b/npm-packages/meteor-vite/src/meteor/IPC/methods/build.ts
@@ -52,37 +52,6 @@ export default CreateIPCInterface({
             throw error;
         }
     },
-    
-    /**
-     * Internal command for spinning up a watcher to rebuild meteor-vite on changes.
-     * Used to ease with the development of this package while running one of the example apps.
-     * Controlled through environment variables applied by the example-app.sh utility script.
-     */
-    async 'tsup.watch.meteor-vite'(reply) {
-        const npmPackagePath = Path.join(process.cwd(), '/node_modules/meteor-vite/') // to the meteor-vite npm package
-        const tsupPath = Path.join(npmPackagePath, '/node_modules/.bin/tsup-node'); // tsup to 2 node_modules dirs down.
-        
-        const child = spawn(tsupPath, ['--watch'], {
-            stdio: 'inherit',
-            cwd: npmPackagePath,
-            detached: false,
-            env: {
-                FORCE_COLOR: '3',
-            },
-        });
-        
-        child.on('error', (error) => {
-            throw new Error(`meteor-vite package build worker error: ${error.message}`, { cause: error })
-        });
-        
-        child.on('exit', (code) => {
-            if (!code) {
-                return;
-            }
-            process.exit(1);
-            throw new Error('TSUp watcher exited unexpectedly!');
-        });
-    }
 })
 
 async function prepareConfig(buildConfig: BuildOptions): Promise<ParsedConfig> {

--- a/npm-packages/meteor-vite/src/meteor/IPC/methods/vite-server.ts
+++ b/npm-packages/meteor-vite/src/meteor/IPC/methods/vite-server.ts
@@ -156,6 +156,33 @@ async function createViteServer({
         ],
     });
     
+    if (viteConfig.meteor?.serverEntry) {
+        build({
+            configFile: viteConfig.configFile,
+            build: {
+                watch: {},
+                lib: {
+                    entry: viteConfig.meteor.serverEntry,
+                    name: 'meteor-server',
+                    fileName: 'meteor.server',
+                    formats: ['es'],
+                },
+                outDir: 'server/bundle',
+                rollupOptions: {
+                    external: (id) => {
+                        if (id.startsWith('meteor')) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }).catch((error) => {
+            Logger.error('Encountered error while preparing server build!', error);
+        }).then(() => {
+            Logger.info('Server build completed!');
+        });
+    }
+    
     process.on('warning', (warning) => {
         if (warning.name !== RefreshNeeded.name) {
             return;

--- a/npm-packages/meteor-vite/src/meteor/IPC/methods/vite-server.ts
+++ b/npm-packages/meteor-vite/src/meteor/IPC/methods/vite-server.ts
@@ -99,6 +99,7 @@ async function createViteServer({
     }
     
     viteConfig = await resolveConfig({
+        mode: 'development',
         configFile: packageJson?.meteor?.vite?.configFile
             // Fallback for deprecated config format
             ?? packageJson?.meteor?.viteConfig,

--- a/npm-packages/meteor-vite/src/meteor/IPC/methods/vite-server.ts
+++ b/npm-packages/meteor-vite/src/meteor/IPC/methods/vite-server.ts
@@ -1,9 +1,10 @@
 import type { MeteorRuntimeConfig } from 'meteor/jorgenvatle:vite-bundler/utility/Helpers';
-import { createServer, resolveConfig, type ResolvedServerUrls, ViteDevServer, build } from 'vite';
+import { createServer, resolveConfig, type ResolvedServerUrls, ViteDevServer } from 'vite';
 import { meteorWorker } from '../../../plugin/Meteor';
 import Logger from '../../../utilities/Logger';
 import { RefreshNeeded } from '../../../ViteLoadRequest';
 import { type ProjectJson, ResolvedMeteorViteConfig } from '../../../VitePluginSettings';
+import { MeteorServerBuilder } from '../../ServerBuilder';
 import { BackgroundWorker, type WorkerRuntimeConfig } from '../BackgroundWorker';
 import { DDPConnection } from '../DDP';
 import CreateIPCInterface, { IPCReply } from '../interface';
@@ -157,30 +158,7 @@ async function createViteServer({
     });
     
     if (viteConfig.meteor?.serverEntry) {
-        build({
-            configFile: viteConfig.configFile,
-            build: {
-                watch: {},
-                lib: {
-                    entry: viteConfig.meteor.serverEntry,
-                    name: 'meteor-server',
-                    fileName: 'meteor.server',
-                    formats: ['es'],
-                },
-                outDir: 'server/bundle',
-                rollupOptions: {
-                    external: (id) => {
-                        if (id.startsWith('meteor')) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }).catch((error) => {
-            Logger.error('Encountered error while preparing server build!', error);
-        }).then(() => {
-            Logger.info('Server build completed!');
-        });
+        await MeteorServerBuilder({ packageJson });
     }
     
     process.on('warning', (warning) => {

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -45,6 +45,7 @@ export async function MeteorServerBuilder({ packageJson }: Pick<DevServerOptions
             },
             sourcemap: true,
             outDir: BUNDLE_OUT.dir,
+            minify: false,
             rollupOptions: {
                 external: (id) => {
                     if (id.startsWith('meteor')) {

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -43,6 +43,7 @@ export async function MeteorServerBuilder({ packageJson }: Pick<DevServerOptions
                 fileName: BUNDLE_OUT.filename,
                 formats: ['es'],
             },
+            sourcemap: true,
             outDir: BUNDLE_OUT.dir,
             rollupOptions: {
                 external: (id) => {

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -3,15 +3,14 @@ import Path from 'path';
 import { build, resolveConfig } from 'vite';
 import { MeteorViteError } from '../error/MeteorViteError';
 import Logger from '../utilities/Logger';
-import { ResolvedMeteorViteConfig } from '../VitePluginSettings';
-import type { DevServerOptions } from './IPC/methods/vite-server';
+import { type ProjectJson, ResolvedMeteorViteConfig } from '../VitePluginSettings';
 
 const BUNDLE_OUT = {
     dir: 'server/bundle',
     filename: 'meteor.server',
 }
 
-export async function MeteorServerBuilder({ packageJson }: Pick<DevServerOptions, 'packageJson'>) {
+export async function MeteorServerBuilder({ packageJson, watch = true }: { packageJson: ProjectJson, watch: boolean }) {
     const viteConfig: ResolvedMeteorViteConfig = await resolveConfig({
         configFile: packageJson?.meteor?.vite?.configFile
             // Fallback for deprecated config format
@@ -37,7 +36,7 @@ export async function MeteorServerBuilder({ packageJson }: Pick<DevServerOptions
         mode: 'meteor-server:development',
         configFile: viteConfig.configFile,
         build: {
-            watch: {},
+            watch: watch ? {} : null,
             lib: {
                 entry: viteConfig.meteor.serverEntry,
                 name: 'meteor-server',

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -1,0 +1,92 @@
+import FS from 'fs/promises';
+import Path from 'path';
+import { build, resolveConfig } from 'vite';
+import { MeteorViteError } from '../error/MeteorViteError';
+import Logger from '../utilities/Logger';
+import { ResolvedMeteorViteConfig } from '../VitePluginSettings';
+import type { DevServerOptions } from './IPC/methods/vite-server';
+
+const BUNDLE_OUT = {
+    dir: 'server/bundle',
+    filename: 'meteor.server',
+}
+
+export async function MeteorServerBuilder({ packageJson }: Pick<DevServerOptions, 'packageJson'>) {
+    const viteConfig: ResolvedMeteorViteConfig = await resolveConfig({
+        configFile: packageJson?.meteor?.vite?.configFile
+            // Fallback for deprecated config format
+            ?? packageJson?.meteor?.viteConfig,
+    }, 'serve');
+    
+    if (!viteConfig.meteor?.serverEntry) {
+        return;
+    }
+    
+    if (!packageJson.meteor.mainModule.server) {
+        throw new MeteorViteError('You need to specify a Meteor server mainModule in your package.json file!')
+    }
+    
+    await prepareServerEntry({
+        meteorMainModule: Path.resolve(packageJson.meteor.mainModule.server),
+        viteServerBundle: Path.resolve(
+            Path.join(BUNDLE_OUT.dir, BUNDLE_OUT.filename)
+        ),
+    })
+    
+    build({
+        configFile: viteConfig.configFile,
+        build: {
+            watch: {},
+            lib: {
+                entry: viteConfig.meteor.serverEntry,
+                name: 'meteor-server',
+                fileName: BUNDLE_OUT.filename,
+                formats: ['es'],
+            },
+            outDir: BUNDLE_OUT.dir,
+            rollupOptions: {
+                external: (id) => {
+                    if (id.startsWith('meteor')) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }).catch((error) => {
+        Logger.error('Encountered error while preparing server build!', error);
+    }).then(() => {
+        Logger.info('Server build completed!');
+    });
+}
+
+async function prepareServerEntry(paths: {
+    meteorMainModule: string;
+    viteServerBundle: string;
+}) {
+    const mainModuleContent = await FS.readFile(paths.meteorMainModule, 'utf8');
+    const relativeViteModulePath = Path.relative(
+        Path.dirname(paths.meteorMainModule),
+        paths.viteServerBundle,
+    );
+    
+    // Add .gitignore to build output
+    {
+        const gitignorePath = Path.join(Path.dirname(paths.viteServerBundle), '.gitignore');
+        await FS.mkdir(Path.dirname(paths.viteServerBundle), { recursive: true });
+        await FS.writeFile(gitignorePath, '*');
+    }
+    
+    // Add import for Vite bundle to server mainModule
+    {
+        const importString = `import ${JSON.stringify('./' + relativeViteModulePath)}`;
+        
+        if (mainModuleContent.includes(importString)) {
+            return;
+        }
+        
+        Logger.info(`Added explicit import for Meteor-Vite server bundle to ${relativeViteModulePath}`);
+        const newMainModuleContent = `${importString}\n${mainModuleContent}`;
+        await FS.writeFile(paths.meteorMainModule, newMainModuleContent);
+    }
+    
+}

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -34,6 +34,7 @@ export async function MeteorServerBuilder({ packageJson }: Pick<DevServerOptions
     })
     
     build({
+        mode: 'development',
         configFile: viteConfig.configFile,
         build: {
             watch: {},

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -34,7 +34,7 @@ export async function MeteorServerBuilder({ packageJson }: Pick<DevServerOptions
     })
     
     build({
-        mode: 'development',
+        mode: 'meteor-server:development',
         configFile: viteConfig.configFile,
         build: {
             watch: {},

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -1,6 +1,6 @@
 import FS from 'fs/promises';
 import Path from 'path';
-import { build, resolveConfig } from 'vite';
+import { build, mergeConfig, resolveConfig } from 'vite';
 import { MeteorViteError } from '../error/MeteorViteError';
 import Logger from '../utilities/Logger';
 import { type ProjectJson, ResolvedMeteorViteConfig } from '../VitePluginSettings';
@@ -46,13 +46,13 @@ export async function MeteorServerBuilder({ packageJson, watch = true }: { packa
             sourcemap: true,
             outDir: BUNDLE_OUT.dir,
             minify: false,
-            rollupOptions: {
-                external: (id) => {
+            rollupOptions: mergeConfig({
+                external: (id: string) => {
                     if (id.startsWith('meteor')) {
                         return true;
                     }
                 }
-            }
+            }, viteConfig.meteor.serverEntryConfig?.build?.rollupOptions || {}, false)
         }
     }).catch((error) => {
         Logger.error('Encountered error while preparing server build!', error);

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -78,7 +78,7 @@ async function prepareServerEntry(paths: {
     
     // Add import for Vite bundle to server mainModule
     {
-        const importString = `import ${JSON.stringify('./' + relativeViteModulePath)}`;
+        const importString = `import(${JSON.stringify('./' + relativeViteModulePath)}).catch((e) => console.warn('Failed to load Vite server bundle. If this is the first time starting the server, you can safely ignore this error.', e))`;
         
         if (mainModuleContent.includes(importString)) {
             return;

--- a/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
+++ b/npm-packages/meteor-vite/src/meteor/ServerBuilder.ts
@@ -10,7 +10,7 @@ const BUNDLE_OUT = {
     filename: 'meteor.server',
 }
 
-export async function MeteorServerBuilder({ packageJson, watch = true }: { packageJson: ProjectJson, watch: boolean }) {
+export async function MeteorServerBuilder({ packageJson, watch = true }: { packageJson: ProjectJson, watch?: boolean }) {
     const viteConfig: ResolvedMeteorViteConfig = await resolveConfig({
         configFile: packageJson?.meteor?.vite?.configFile
             // Fallback for deprecated config format

--- a/package-lock.json
+++ b/package-lock.json
@@ -2329,6 +2329,7 @@
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
       "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "date-fns": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -16,30 +16,24 @@
   "scripts": {
     "version:vite-bundler": "meteor node .bin/release-meteor-package.mjs version",
     "publish:vite-bundler": "meteor node .bin/release-meteor-package.mjs publish",
-
     "example": ".bin/example-app.sh",
     "launch": "npm run example launch",
-
     "version": "(npm run version:vite-bundler || exit 1) && changeset version",
     "release": "npm run publish:vite-bundler && changeset publish",
-
     "install:svelte": "cd examples/svelte && meteor npm install",
     "install:vue": "cd examples/vue && meteor npm install",
     "install:react": "cd examples/react && meteor npm install",
     "install:package": "cd npm-packages/meteor-vite && meteor npm install",
-
     "build": "npm run example build",
     "build:package": "cd npm-packages/meteor-vite && meteor npm run build",
     "build:vue": "npm run example build vue",
     "build:react": "npm run example build react",
     "build:svelte": "npm run example build svelte",
-
     "link": "npm run example link",
     "link:package": "meteor npm run link:vue && meteor npm run link:svelte",
     "link:vue": "npm run example link vue",
     "link:svelte": "npm run example link svelte",
     "link:react": "npm run example link react",
-
     "start": "npm run example start",
     "start:vue": "npm run example start vue",
     "start:svelte": "npm run example start svelte",

--- a/package.json
+++ b/package.json
@@ -14,29 +14,25 @@
     "concurrently": "^8.2.2"
   },
   "scripts": {
+    "start": "npm run example start",
+    "launch": "npm run example launch",
+    "build": "npm run example build",
+    "link": "npm run example link",
+
+    "release": "npm run publish:vite-bundler && changeset publish",
+    "version": "(npm run version:vite-bundler || exit 1) && changeset version",
+
+    "example": ".bin/example-app.sh",
+
     "version:vite-bundler": "meteor node .bin/release-meteor-package.mjs version",
     "publish:vite-bundler": "meteor node .bin/release-meteor-package.mjs publish",
-    "example": ".bin/example-app.sh",
-    "launch": "npm run example launch",
-    "version": "(npm run version:vite-bundler || exit 1) && changeset version",
-    "release": "npm run publish:vite-bundler && changeset publish",
-    "install:svelte": "cd examples/svelte && meteor npm install",
-    "install:vue": "cd examples/vue && meteor npm install",
-    "install:react": "cd examples/react && meteor npm install",
-    "install:package": "cd npm-packages/meteor-vite && meteor npm install",
-    "build": "npm run example build",
+
+    "start:vue": "npm start vue",
+    "start:react": "npm start react",
+    "start:<example app>": "npm start <example app>",
+
     "build:package": "cd npm-packages/meteor-vite && meteor npm run build",
-    "build:vue": "npm run example build vue",
-    "build:react": "npm run example build react",
-    "build:svelte": "npm run example build svelte",
-    "link": "npm run example link",
-    "link:package": "meteor npm run link:vue && meteor npm run link:svelte",
-    "link:vue": "npm run example link vue",
-    "link:svelte": "npm run example link svelte",
-    "link:react": "npm run example link react",
-    "start": "npm run example start",
-    "start:vue": "npm run example start vue",
-    "start:svelte": "npm run example start svelte",
-    "start:react": "npm run example start react"
+    "install:package": "cd npm-packages/meteor-vite && meteor npm install",
+    "link:package": "meteor npm run link:vue && meteor npm run link:svelte"
   }
 }

--- a/packages/vite-bundler/vite-server.ts
+++ b/packages/vite-bundler/vite-server.ts
@@ -14,7 +14,6 @@ import { getMeteorRuntimeConfig } from './utility/Helpers';
 import { createWorkerFork, getProjectPackageJson, isMeteorIPCMessage } from './workers';
 
 if (Meteor.isDevelopment) {
-    let tsupWatcherRunning = false;
     DevConnectionLog.info('Starting Vite server...');
     
     WebAppInternals.registerBoilerplateDataCallback('meteor-vite', async (request: HTTP.IncomingMessage, data: BoilerplateData) => {
@@ -32,22 +31,6 @@ if (Meteor.isDevelopment) {
         refreshNeeded() {
             DevConnectionLog.info('Some lazy-loaded packages were imported, please refresh')
         },
-        
-        /**
-         * Builds the 'meteor-vite' npm package where the worker and Vite server is kept.
-         * Primarily to ease the testing process for the Vite plugin.
-         */
-        workerConfig({ listening }) {
-            if (!listening) return;
-            if (process.env.METEOR_VITE_TSUP_BUILD_WATCHER !== 'true') return;
-            if (tsupWatcherRunning) return;
-            
-            tsupWatcherRunning = true;
-            viteServer.call({
-                method: 'tsup.watch.meteor-vite',
-                params: [],
-            })
-        }
     }, { detached: true });
     
     viteServer.call({

--- a/packages/vite-bundler/vite-server.ts
+++ b/packages/vite-bundler/vite-server.ts
@@ -2,7 +2,6 @@ import type HTTP from 'http';
 import { fetch } from 'meteor/fetch';
 import { Meteor } from 'meteor/meteor';
 import { WebAppInternals } from 'meteor/webapp';
-import { IpcCollection } from './api/Collections';
 import { DDP_IPC } from './api/DDP-IPC';
 import {
     DevConnectionLog,

--- a/packages/vite-bundler/workers.ts
+++ b/packages/vite-bundler/workers.ts
@@ -23,10 +23,6 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>, options?: 
     }
     validateNpmVersion();
     
-    if (options?.ipc) {
-        options.ipc.setResponseHooks(hooks);
-    }
-    
     const child = fork(workerPath, ['--enable-source-maps'], {
         stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
         cwd,
@@ -55,6 +51,10 @@ export function createWorkerFork(hooks: Partial<WorkerResponseHooks>, options?: 
                 `Is vite server: ${listening}`,
             ].join('\n   '));
         }
+    }
+    
+    if (options?.ipc) {
+        options.ipc.setResponseHooks(hooks);
     }
     
     child.on('message', (message: WorkerResponse & { data: any }) => {


### PR DESCRIPTION
Added an experimental build option for pre-bundling the Meteor server using Vite. This should noticeably improve time-to-restart performance for larger apps, particularly those that rely on any Atmosphere build plugins (e.g. `typescript`). And most importantly, gives you the full flexibility of Vite's build system, but for your server. ⚡