### PR TITLE
fix: Don't add html boilerplate on build if dynamic boilerplate is enabled

### DIFF
--- a/packages/vite/src/entry/build-plugin.ts
+++ b/packages/vite/src/entry/build-plugin.ts
@@ -34,7 +34,9 @@ class CompilerPlugin {
             
             Logger.debug(`[${Colorize.arch(file.getArch())}] Processing: ${fileMeta.basename}`, Colorize.object({ fileMeta }));
             
-            this.addHtmlBoilerplate(file);
+            if (!this.config.dynamicAssetBoilerplate) {
+                this.addHtmlBoilerplate(file);
+            }
             
             if (this.config.mode !== 'production') {
                 return;


### PR DESCRIPTION
Fixes #335 