### PR TITLE
Fix Windows Vite asset keys in production bundles

### DIFF
--- a/npm-packages/meteor-vite/src/internals/lib/MeteorViteCompilerPlugin.ts
+++ b/npm-packages/meteor-vite/src/internals/lib/MeteorViteCompilerPlugin.ts
@@ -25,7 +25,7 @@ export class MeteorViteCompilerPlugin {
                     path: file.getPathInPackage(),
                 },
                 basename: this._formatFilename(file.getBasename()),
-                path: Path.join(this.config.assetsDir, Path.relative(this.config.outDir, this._formatFilename(file.getPathInPackage()))),
+                path: this._createAssetPath(file.getPathInPackage()),
                 arch: file.getArch(),
             }
             
@@ -96,6 +96,19 @@ export class MeteorViteCompilerPlugin {
     
     protected _formatFilename(nameOrPath: string) {
         return nameOrPath.replace(`.${CurrentConfig.bundleFileExtension}`, '');
+    }
+
+    /**
+     * Meteor asset identifiers are logical bundle keys, not filesystem paths.
+     * Keep them POSIX-style so runtime lookups like `Assets.getTextAsync('vite/client.manifest.json')`
+     * resolve consistently across platforms.
+     */
+    protected _createAssetPath(filePath: string) {
+        const relativePath = Path.relative(this.config.outDir, this._formatFilename(filePath));
+        const normalizedAssetsDir = Path.posix.normalize(this.config.assetsDir.replaceAll('\\', '/'));
+        const normalizedRelativePath = Path.posix.normalize(relativePath.replaceAll('\\', '/'));
+
+        return Path.posix.join(normalizedAssetsDir, normalizedRelativePath);
     }
     
     protected _sourcemap(file: InputFile) {


### PR DESCRIPTION
Fixes #371

On Windows, I reproduced a production startup failure where runtime requests `vite/client.manifest.json`, but the built Meteor asset map stores the key as `vite\\client.manifest.json`.

This change treats Meteor asset identifiers as logical bundle keys rather than filesystem paths, and normalizes them to POSIX-style separators before storing them.

I was not able to fully validate the fix in a local forked build because repository bootstrap failed on my machine during `npm install`, but the change is based on reproduced Windows build output and the affected path-construction logic.
